### PR TITLE
node.js: Ensure ordering of events on socket send

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -165,12 +165,13 @@ class rtpnode {
    * @param { object } connection
    * @returns { void }
    */
-  send( msg, connection ) {
+  send( msg, connection, cb = undefined ) {
     this._post( msg, ( modifiedmsg ) => {
       if( this._destroying ) return
       msg.status = this.prtp.stats()
       msg.status.instance = instance
       connection.write( message.createmessage( modifiedmsg ) )
+      if (cb !== undefined) cb(msg)
     } )
   }
 
@@ -292,17 +293,22 @@ class rtpnode {
     con.connectionlength += 1
     msg.forcelocal = true
 
-    const chan = await this.prtp.openchannel( msg, ( x ) => {
-      this.send( { ...{ "id": chan.id, "uuid": chan.uuid }, ...x }, con.connection )
-      if( "close" === x.action )  {
-        con.connectionlength -= 1
-        channels.delete( chan.uuid )
+    const chan = await this.prtp.openchannel( msg, ( cookie ) => {
+      // TODO: we might want to ensure the actual event has been written
+      // to the server before cleaning up the channel on our side?
+      this.send( { ...{ "id": chan.id, "uuid": chan.uuid }, ...cookie },
+        con.connection,
+        ( cookie ) => {
+          if ( "close" === cookie.action )  {
+            con.connectionlength -= 1
+            channels.delete( chan.uuid )
 
-        if( 0 == con.connectionlength && "listen" == con.mode ) {
-          this.connections.delete( con.instance )
-          con.connection.destroy()
-        }
-      }
+            if( 0 == con.connectionlength && "listen" == con.mode ) {
+              this.connections.delete( con.instance )
+              con.connection.destroy()
+            }
+          }
+        } )
     } )
     channels.set( chan.uuid, chan )
     this.send( { ...chan, ...{ "action": "open" } }, con.connection )


### PR DESCRIPTION
* In previous commit(s) 00966f3161bee77617dca35a59f852232e5ccfd3 we introduced a regression in which babble-sip wasn't receiving play:end and close events. This was due to the fact that we were closing the channel before socket.write had the chance to finish.
* In this fix we introduce a callback to the send function so that we can execute the cleanup code after socket.write has returned.
* Helps with babblevoice/babble-sip#35.