### PR TITLE
problem with message without decent digits causes unhandled exception

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -15,7 +15,12 @@ const channelmap = {
     }
   },
   "unmix": ( chan ) => chan.unmix(),
-  "dtmf": ( chan, msg ) => chan.dtmf( msg.digits ),
+  "dtmf": ( chan, msg ) => {
+    if( !msg.digits ) return
+    if( "string" !== typeof msg.digits ) return
+    if( 10 < msg.digits.length ) return
+    chan.dtmf( msg.digits )
+  },
   "echo": ( chan ) => chan.echo(),
   "play": ( chan, msg ) => chan.play( msg.soup ),
   "record": ( chan, msg ) => chan.record( msg.options ),


### PR DESCRIPTION
When p[assing in a dtmf command perform a santiy check to prevent exception.