### PR TITLE
Bug stop playback on mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you wish to build outsode of a Docker image, there are npm target scripts for
 
 ```bash
 docker buildx prune
-docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.5.29 . --push
+docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.5.36 . --push
 ```
 
 ## Example scripts


### PR DESCRIPTION
There appear to be a few calls where mix starts but are hung up without hanging up the other legs which means the channel reverts to playback whatever the last play was - I think that might be being confused with crossed lines.