### PR TITLE
Bug fix hanging on connection tests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -103,8 +103,9 @@ class channel {
   openresolve
 
   /**
+   * listening or connection
    * @private
-   * @type { string }
+   * @type { "l" | "c" }
    */
   ctype
 
@@ -346,6 +347,7 @@ class channel {
       const newchannel = new channel()
       if( cb ) newchannel.em.on( "all", cb )
 
+      newchannel.ctype = this.ctype
       newchannel.connection = this.connection
       newchannel.channels = this.channels
       newchannel.channels.push( newchannel )
@@ -541,7 +543,7 @@ class channel {
   }
 
   /**
-   * We have received teh open confirm message so we should action it
+   * We have received the open confirm message so we should action it
    * @private
    * @param { object } msg
    * @returns { boolean } - is further processing required
@@ -592,14 +594,17 @@ class channel {
   }
 
   #cleanupsharedchannels() {
-    if( this.channels ) { 
-      // adjust with filter
-      const index = this.channels.indexOf( this )
-      if( -1 < index ) this.channels.splice( index, 1 )
-      if( this.ctype == "c" && 0 === this.channels.length && this.connection.sock ) {
-        this.connection.sock.destroy()
-      }
-    }
+    if( !this.channels ) return
+
+    // adjust with filter
+    const index = this.channels.indexOf( this )
+    if( -1 < index ) this.channels.splice( index, 1 )
+
+    if( "c" !== this.ctype ) return
+    if( 0 !== this.channels.length ) return
+    if( !this.connection.sock ) return
+
+    this.connection.sock.destroy()
   }
 
   #haserror( msg ) {


### PR DESCRIPTION
After running a full suite of tests the test suite would not exit properly as some connections did not close cleanly.

This was mainly because the simulated node did not send a close message in response to a close request so the close functions did not happen (although they would in time with timeouts).

This also exposed a real bug where second channels on a connection did not trigger a close if they were the final connection. This has been fixed as part of this PR.