### PR TITLE
Bug create our own 2833 not forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you wish to build outsode of a Docker image, there are npm target scripts for
 
 ```bash
 docker buildx prune
-docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.5.37_beta22 . --push
+docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.6.1_beta2 . --push
 ```
 
 ### Dev build

--- a/src/projectrtpchannel.h
+++ b/src/projectrtpchannel.h
@@ -114,6 +114,7 @@ public:
   bool mix( projectrtpchannel::pointer other );
   bool unmix( void );
   void dtmf( std::string digits );
+  void dtmf( char digit );
   rtppacket *gettempoutbuf( void );
 
   std::atomic_uint32_t codec;

--- a/src/projectrtpchannelmux.h
+++ b/src/projectrtpchannelmux.h
@@ -35,6 +35,7 @@ public:
   inline size_t size() { return this->channels.size(); }
   void addchannel( projectrtpchannelptr chan );
   void addchannels( projectrtpchannelptr chana, projectrtpchannelptr chanb );
+  void senddtmf( projectrtpchannelptr from, char digit );
   void go( void );
 
 private:


### PR DESCRIPTION
We are seeing too many problems simply forward 2833 onto the remote end - where all phones are configured differently for duration, volume, dumping all packets on the wire immediately and so on.

This makes it uniform in how we send to the end points to ensure we have one mechanism to tweak whilst we can be more forgiving to our end points.