### PR TITLE
dtmf event timestamps are locked to event

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you wish to build outsode of a Docker image, there are npm target scripts for
 
 ```bash
 docker buildx prune
-docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.6.1_beta2 . --push
+docker buildx build --platform linux/amd64,linux/arm64 -t tinpotnick/projectrtp:2.6.1 . --push
 ```
 
 ### Dev build

--- a/src/projectrtpchannel.h
+++ b/src/projectrtpchannel.h
@@ -121,6 +121,7 @@ public:
   uint32_t ssrcin;
   uint32_t ssrcout;
   uint32_t tsout;
+  uint32_t eventtsout;
   uint16_t snout;
 
   /* do we send, do we receive */


### PR DESCRIPTION
The implementation wasn't correct to the rfc in that the timestamp for the rtp event is locked to the event not to each packet - to single all events as one.