### PR TITLE
Crash bug fixing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "2.6.24",
+  "version": "2.6.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/projectrtp",
-      "version": "2.6.24",
+      "version": "2.6.25",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "2.6.24",
+  "version": "2.6.25",
   "description": "A scalable Node addon RTP server",
   "main": "index.js",
   "directories": {

--- a/src/projectrtpchannel.cpp
+++ b/src/projectrtpchannel.cpp
@@ -287,6 +287,11 @@ void projectrtpchannel::remote( std::string address,
       }
       this->earlydtls.clear();
     }
+
+    /* kick off the DTLS handshake immediately rather than waiting for
+       the next tick - avoids burning through gnutls retransmission
+       budget since our pull_timeout returns instantly */
+    this->dtlsnegotiate();
   }
 }
 

--- a/src/projectrtpsoundfile.cpp
+++ b/src/projectrtpsoundfile.cpp
@@ -22,6 +22,7 @@ soundfile::soundfile( int fromfile ) :
   ourwavheader(),
   currentcbindex( 0 ),
   cbwavheader(),
+  headerneedsreap( false ),
   buffer(),
   filelock( true /* initialised as locked */ ) {
 
@@ -36,6 +37,8 @@ soundfile::soundfile( int fromfile ) :
   for( auto i = 0; i < SOUNDFILENUMBUFFERS; i++ ) {
     soundbuffer &thisbuffer = this->buffer[ i ];
     aiocb &thisblock = this->cbwavblock[ i ];
+
+    this->blockneedsreap[ i ] = false;
 
     thisbuffer.reserve( AIOCBBUFFERNUMSAMPLES );
 
@@ -59,6 +62,19 @@ soundfile::~soundfile() {
     /* Is there a better way? Not waiting for the cancel can can cause the async
     opperation to write to our buffer which is much worse */
     while( AIO_NOTCANCELED == aio_cancel( this->file, NULL ) );
+
+    /* reap any operations that weren't already reaped during normal use */
+    for( auto i = 0; i < SOUNDFILENUMBUFFERS; i++ ) {
+      if( this->blockneedsreap[ i ] ) {
+        aio_return( &this->cbwavblock[ i ] );
+        this->blockneedsreap[ i ] = false;
+      }
+    }
+    if( this->headerneedsreap ) {
+      aio_return( &this->cbwavheader );
+      this->headerneedsreap = false;
+    }
+
     close( this->file );
     this->file = -1;
   }
@@ -150,6 +166,7 @@ soundfilereader::soundfilereader( std::string &url ) :
     releasespinlock( this->filelock );
     return;
   }
+  this->headerneedsreap = true;
 
   releasespinlock( this->filelock );
 	return;
@@ -178,6 +195,8 @@ void soundfilereader::parseheader( void ) {
     return;
   }
 
+  aio_return( &this->cbwavheader );
+  this->headerneedsreap = false;
   this->headerread = true;
 
   if( 'W' != this->ourwavheader.wave_header[ 0 ] ) {
@@ -247,6 +266,8 @@ void soundfilereader::parseheader( void ) {
   aiocb &thisblock = this->cbwavblock[ thisindex ];
   if ( aio_read( &thisblock ) == -1 ) {
     this->bodyread = true;
+  } else {
+    this->blockneedsreap[ thisindex ] = true;
   }
 }
 
@@ -290,6 +311,12 @@ bool soundfilereader::read( rawsound &out ) {
   auto thisindex = this->currentcbindex % SOUNDFILENUMBUFFERS;
   aiocb &thisblock = this->cbwavblock[ thisindex ];
 
+  if( !this->blockneedsreap[ thisindex ] ) {
+    /* no aio operation was started on this buffer - return silence */
+    out.zero();
+    return true;
+  }
+
   if( aio_error( &thisblock ) == EINPROGRESS ) {
     /* return some silence */
     out.zero();
@@ -298,6 +325,7 @@ bool soundfilereader::read( rawsound &out ) {
 
   /* success? */
   auto numbytes = aio_return( &thisblock );
+  this->blockneedsreap[ thisindex ] = false;
 
   if( -1 == numbytes ) {
     fprintf( stderr, "Bad call to aio_return on %s at offset %lld errno %d\n",
@@ -327,17 +355,23 @@ bool soundfilereader::read( rawsound &out ) {
   aiocb &nextblock = this->cbwavblock[ this->currentcbindex ];
   soundbuffer &thisbuffer = this->buffer[ this->currentcbindex ];
 
-  /* reap any completed aio on the buffer we are about to reuse */
-  if( aio_error( &nextblock ) != EINPROGRESS ) {
-    aio_return( &nextblock );
+  /* Do not touch the aiocb or its buffer while an operation is in progress -
+     reusing an aiocb with an in-flight op is undefined behaviour and corrupts
+     musl's internal aio thread pool state. Skip queuing; the next tick will
+     pick up the completed buffer. */
+  if( aio_error( &nextblock ) == EINPROGRESS ) {
+    return true;
   }
+  aio_return( &nextblock );
+  this->blockneedsreap[ this->currentcbindex ] = false;
 
   /* it shouldn't reallocate - but just in case */
   thisbuffer.resize( this->bytecount );
   nextblock.aio_buf = thisbuffer.data();
 
   off_t nextoffset = lastreadoffset + this->bytecount;
-  if( nextoffset >= ( off_t ) ( sizeof( wavheader ) + this->ourwavheader.subchunksize ) ) {
+  off_t dataend = ( off_t ) ( sizeof( wavheader ) + this->ourwavheader.subchunksize );
+  if( nextoffset >= dataend ) {
     nextblock.aio_offset = sizeof( wavheader );
     this->bodyread = true;
   } else {
@@ -353,6 +387,7 @@ bool soundfilereader::read( rawsound &out ) {
     this->bodyread = true;
     return false;
   }
+  this->blockneedsreap[ this->currentcbindex ] = true;
 
   return true;
 }
@@ -377,6 +412,15 @@ void soundfilereader::realsetposition( long mseconds ) {
 
   while( AIO_NOTCANCELED == aio_cancel( this->file, NULL ) );
 
+  /* reap every cancelled/completed operation before reusing the aiocbs -
+     skipping this leaves musl's aio thread pool in an inconsistent state */
+  for( auto i = 0; i < SOUNDFILENUMBUFFERS; i++ ) {
+    if( this->blockneedsreap[ i ] ) {
+      aio_return( &this->cbwavblock[ i ] );
+      this->blockneedsreap[ i ] = false;
+    }
+  }
+
   this->bodyread = false;
 
   this->currentcbindex = 0;
@@ -398,6 +442,8 @@ void soundfilereader::realsetposition( long mseconds ) {
 
   if ( aio_read( &thisblock ) == -1 ) {
     this->bodyread = true;
+  } else {
+    this->blockneedsreap[ 0 ] = true;
   }
 
   this->initseekmseconds = 0;
@@ -495,6 +541,7 @@ soundfilewriter::soundfilewriter( std::string &url, int16_t numchannels, int32_t
     releasespinlock( this->filelock );
     return;
   }
+  this->headerneedsreap = true;
 
   releasespinlock( this->filelock );
 	return;
@@ -540,13 +587,15 @@ bool soundfilewriter::isclosed( void ) {
         }
       }
 
-      /* collect completed aio results */
-      if( 0 == aio_error( &this->cbwavheader ) ) {
+      /* reap all completed aio results (success or error) */
+      if( this->headerneedsreap ) {
         aio_return( &this->cbwavheader );
+        this->headerneedsreap = false;
       }
       for( auto i = 0; i < SOUNDFILENUMBUFFERS; i++ ) {
-        if( 0 == aio_error( &this->cbwavblock[ i ] ) ) {
+        if( this->blockneedsreap[ i ] ) {
           aio_return( &this->cbwavblock[ i ] );
+          this->blockneedsreap[ i ] = false;
         }
       }
 
@@ -560,6 +609,7 @@ bool soundfilewriter::isclosed( void ) {
         this->file = -1;
         return true;
       }
+      this->headerneedsreap = true;
       this->_closestate = closestate::writingheader;
       return false;
     }
@@ -568,7 +618,10 @@ bool soundfilewriter::isclosed( void ) {
       if( EINPROGRESS == aio_error( &this->cbwavheader ) ) {
         return false;
       }
-      aio_return( &this->cbwavheader );
+      if( this->headerneedsreap ) {
+        aio_return( &this->cbwavheader );
+        this->headerneedsreap = false;
+      }
 
       /* kick off async fsync */
       if( -1 == aio_fsync( O_SYNC, &this->cbwavheader ) ) {
@@ -577,6 +630,7 @@ bool soundfilewriter::isclosed( void ) {
         this->file = -1;
         return true;
       }
+      this->headerneedsreap = true;
       this->_closestate = closestate::syncing;
       return false;
     }
@@ -585,7 +639,10 @@ bool soundfilewriter::isclosed( void ) {
       if( EINPROGRESS == aio_error( &this->cbwavheader ) ) {
         return false;
       }
-      aio_return( &this->cbwavheader );
+      if( this->headerneedsreap ) {
+        aio_return( &this->cbwavheader );
+        this->headerneedsreap = false;
+      }
 
       close( this->file );
       this->file = -1;
@@ -695,8 +752,9 @@ bool soundfilewriter::write( codecx &in, codecx &out ) {
     fprintf( stderr, "soundfile trying to write a packet whilst last is still in progress\n" );
     return false;
   }
-  if( 0 == aioerr ) {
+  if( this->blockneedsreap[ thisindex ] ) {
     aio_return( &thisblock );
+    this->blockneedsreap[ thisindex ] = false;
   }
 
   auto numchannels = this->ourwavheader.num_channels;
@@ -737,6 +795,7 @@ bool soundfilewriter::write( codecx &in, codecx &out ) {
     fprintf( stderr, "soundfile unable to write wav block to file %s\n", this->url.c_str() );
     return false;
   }
+  this->blockneedsreap[ thisindex ] = true;
 
   uint32_t dataend = thisblock.aio_offset + thisblock.aio_nbytes - sizeof( wavheader );
   if( dataend > this->ourwavheader.subchunksize ) {
@@ -745,9 +804,14 @@ bool soundfilewriter::write( codecx &in, codecx &out ) {
 
     /* Update the wav header with size */
     if( aio_error( &this->cbwavheader ) != EINPROGRESS ) {
-      aio_return( &this->cbwavheader );
+      if( this->headerneedsreap ) {
+        aio_return( &this->cbwavheader );
+        this->headerneedsreap = false;
+      }
       if ( aio_write( &this->cbwavheader ) == -1 ) {
         fprintf( stderr, "soundfile unable to update wav header to file %s\n", this->url.c_str() );
+      } else {
+        this->headerneedsreap = true;
       }
     }
   }
@@ -797,9 +861,9 @@ bool soundfilewriter::drainpending( void ) {
     if( aioerr == EINPROGRESS ) {
       break; /* buffer still in flight - continue next tick */
     }
-    /* reap completed operation before reusing this aiocb */
-    if( 0 == aioerr ) {
+    if( this->blockneedsreap[ thisindex ] ) {
       aio_return( &thisblock );
+      this->blockneedsreap[ thisindex ] = false;
     }
 
     size_t remaining = this->pendingsamples.size() - this->pendingoffset;
@@ -823,6 +887,7 @@ bool soundfilewriter::drainpending( void ) {
       fprintf( stderr, "soundfile unable to write pending block to file %s\n", this->url.c_str() );
       break;
     }
+    this->blockneedsreap[ thisindex ] = true;
     drainedchunks++;
 
     uint32_t dataend = thisblock.aio_offset + thisblock.aio_nbytes - sizeof( wavheader );
@@ -831,9 +896,14 @@ bool soundfilewriter::drainpending( void ) {
       this->ourwavheader.chunksize = dataend + 36;
 
       if( aio_error( &this->cbwavheader ) != EINPROGRESS ) {
-        aio_return( &this->cbwavheader );
+        if( this->headerneedsreap ) {
+          aio_return( &this->cbwavheader );
+          this->headerneedsreap = false;
+        }
         if( aio_write( &this->cbwavheader ) == -1 ) {
           fprintf( stderr, "soundfile unable to update wav header to file %s\n", this->url.c_str() );
+        } else {
+          this->headerneedsreap = true;
         }
       }
     }

--- a/src/projectrtpsoundfile.h
+++ b/src/projectrtpsoundfile.h
@@ -90,6 +90,10 @@ protected:
   aiocb cbwavheader;
   aiocb cbwavblock[ SOUNDFILENUMBUFFERS ];
 
+  /* track whether each aiocb has an outstanding operation needing aio_return */
+  bool headerneedsreap;
+  bool blockneedsreap[ SOUNDFILENUMBUFFERS ];
+
   /* buffer for data */
   soundbuffer buffer[ SOUNDFILENUMBUFFERS ];
 

--- a/src/projectrtpsrtp.cpp
+++ b/src/projectrtpsrtp.cpp
@@ -89,7 +89,10 @@ dtlssession::dtlssession( dtlssession::mode mode ) :
   gnutlserrorcheck( gnutls_srtp_set_profile( this->session, GNUTLS_SRTP_AES128_CM_HMAC_SHA1_80 ), "gnutls_srtp_set_profile" ); // or maybe GNUTLS_SRTP_AES128_CM_HMAC_SHA1_32?
   gnutls_transport_set_ptr( this->session, this );
 
-  gnutls_dtls_set_timeouts( this->session, 500, 60 * 1000 );
+  /* retransmission timeout must be short since our pull_timeout callback
+     returns immediately (non-blocking tick-based design). GnuTLS doubles
+     the timeout after each cycle, so 200ms → 400ms → 800ms... */
+  gnutls_dtls_set_timeouts( this->session, 200, 10000 );
 
   gnutls_transport_set_push_function( this->session, [] ( gnutls_transport_ptr_t p, const void *data, size_t size ) -> ssize_t {
     ( ( dtlssession * )( p ) )->push( data, size );
@@ -169,8 +172,10 @@ int dtlssession::timeout( unsigned int ms ) {
     return 1;
   }
 
-  gnutls_transport_set_errno( this->session, EAGAIN );
-  return -1;
+  /* no data available - return 0 (timeout elapsed) so gnutls handles
+     retransmission internally. returning -1 would signal a transport
+     error and cause the handshake to fail with GNUTLS_E_TIMEDOUT */
+  return 0;
 }
 
 

--- a/test/interface/projectrtpsound.js
+++ b/test/interface/projectrtpsound.js
@@ -373,36 +373,39 @@ describe( "rtpsound", function() {
     let done
     const finished = new Promise( ( r ) => { done = r } )
 
+    /* Track the sequence of PCMA values across file transitions.
+       flat=228, flat2=223, flat3=220. flat.wav plays twice (loop=2) so
+       no value change between loops. The value sequence is:
+       228 → 223 → 228 → 220 → (outer loop restart) 228 → 223 → 228 → 220
+       So transitions TO: 223, 228, 220, 228, 223, 228, 220 */
+    const expectedtransitions = [ 223, 228, 220, 228, 223, 228, 220 ]
+    let transindex = 0
+    let lastvalue = 0
+
     // eslint-disable-next-line complexity
     server.on( "message", function( msg ) {
 
       receviedpkcount++
-      const secondouterloopoffset = 205
 
-      /* This is PCMA encoded data from our soundsoup */
-      if( 25 == receviedpkcount || ( 25 + secondouterloopoffset ) == receviedpkcount ) {
-        /* flat.wav first loop */
-        expect( msg[ 17 ] ).to.equal( 228 )
-        expect( msg[ 150 ] ).to.equal( 228 )
-      } else if( 75 == receviedpkcount || ( 75 + secondouterloopoffset ) == receviedpkcount ) {
-        /* flat.wav second loop */
-        expect( msg[ 17 ] ).to.equal( 228 )
-        expect( msg[ 150 ] ).to.equal( 228 )
-      } else if( 125 == receviedpkcount || ( 125 + secondouterloopoffset ) == receviedpkcount ) {
-        /* flat2.wav */
-        expect( msg[ 17 ] ).to.equal( 223 )
-        expect( msg[ 150 ] ).to.equal( 223 )
-      } else if( 175 == receviedpkcount || ( 175 + secondouterloopoffset ) == receviedpkcount ) {
-        /* flat.wav */
-        expect( msg[ 17 ] ).to.equal( 228 )
-        expect( msg[ 150 ] ).to.equal( 228 )
-      } else if( 206 == receviedpkcount || 413 == receviedpkcount ) {
-        /* flat3.wav */
-        expect( msg[ 17 ] ).to.equal( 220 )
-        expect( msg[ 150 ] ).to.equal( 220 )
-      } else if( ( 207 * 2 ) == receviedpkcount ) {
-        enoughpackets()
+      const val = msg[ 17 ]
+      if( 0 == val ) return
+
+      if( val !== lastvalue && 0 !== lastvalue ) {
+        /* value transition — verify against expected order */
+        if( transindex < expectedtransitions.length ) {
+          expect( val ).to.equal( expectedtransitions[ transindex ] )
+          transindex++
+        }
+
+        if( transindex >= expectedtransitions.length ) {
+          enoughpackets()
+        }
+      } else if( 0 === lastvalue ) {
+        /* first non-zero packet — should be flat.wav */
+        expect( val ).to.equal( 228 )
       }
+
+      lastvalue = val
     } )
 
     server.bind()
@@ -629,6 +632,137 @@ describe( "rtpsound", function() {
     prtp.projectrtp.tone.generate( "440/0:400/350/225/525", uktones )
     prtp.projectrtp.tone.generate( "440/0:125/125", uktones )
 
+  } )
+
+  it( "rapid play replacement stresses aio cancel and reap", async function() {
+
+    /*
+    Rapidly replace the player 20 times in quick succession. Each replacement
+    triggers setposition (aio_cancel + reap) on the old file and starts reading
+    the new file. This exercises the aio lifecycle under pressure:
+    - cancel in-flight operations
+    - reap cancelled operations (needsreap tracking)
+    - start new operations on reused aiocbs
+    - destructor cleanup of abandoned files
+    */
+
+    this.timeout( 5000 )
+    this.slow( 3000 )
+
+    const server = dgram.createSocket( "udp4" )
+    let receviedpkcount = 0
+
+    server.on( "message", function() { receviedpkcount++ } )
+
+    let done
+    const finished = new Promise( r => { done = r } )
+
+    server.bind()
+    await new Promise( resolve => server.on( "listening", resolve ) )
+
+    const ourport = server.address().port
+    const channel = await prtp.projectrtp.openchannel( { "remote": { "address": "127.0.0.1", "port": ourport, "codec": 0 } }, function( d ) {
+      if( "close" === d.action ) done()
+    } )
+
+    /* rapidly replace the player */
+    for( let i = 0; i < 20; i++ ) {
+      const file = ( 0 == i % 2 ) ? "/tmp/flat.wav" : "/tmp/flat2.wav"
+      expect( channel.play( { "files": [ { "wav": file } ] } ) ).to.be.true
+      await new Promise( r => setTimeout( r, 30 ) )
+    }
+
+    /* let the last file play out */
+    await new Promise( r => setTimeout( r, 1200 ) )
+
+    channel.close()
+    server.close()
+
+    await finished
+
+    expect( receviedpkcount ).to.be.above( 30 )
+  } )
+
+  it( "many short files in soundsoup stresses file transitions", async function() {
+
+    /*
+    A soundsoup with many very short plays (using start/stop) forces
+    rapid file transitions. Each transition goes through plusone →
+    setposition → aio_cancel → reap → new aio_read. With 10 files
+    playing ~3 packets each, we get ~10 transitions in quick succession.
+    */
+
+    this.timeout( 5000 )
+    this.slow( 3000 )
+
+    const server = dgram.createSocket( "udp4" )
+    let receviedpkcount = 0
+
+    server.on( "message", function() { receviedpkcount++ } )
+
+    let done
+    const finished = new Promise( r => { done = r } )
+
+    server.bind()
+    await new Promise( resolve => server.on( "listening", resolve ) )
+
+    const ourport = server.address().port
+    const channel = await prtp.projectrtp.openchannel( { "remote": { "address": "127.0.0.1", "port": ourport, "codec": 0 } }, function( d ) {
+      if( "close" === d.action ) done()
+    } )
+
+    expect( channel.play( { "files": [
+      { "wav": "/tmp/flat.wav", "start": 0, "stop": 60 },
+      { "wav": "/tmp/flat2.wav", "start": 0, "stop": 60 },
+      { "wav": "/tmp/flat.wav", "start": 100, "stop": 160 },
+      { "wav": "/tmp/flat2.wav", "start": 200, "stop": 260 },
+      { "wav": "/tmp/flat.wav", "start": 300, "stop": 360 },
+      { "wav": "/tmp/flat2.wav", "start": 400, "stop": 460 },
+      { "wav": "/tmp/flat.wav", "start": 500, "stop": 560 },
+      { "wav": "/tmp/flat2.wav", "start": 600, "stop": 660 },
+      { "wav": "/tmp/flat.wav", "start": 700, "stop": 760 },
+      { "wav": "/tmp/flat3.wav", "start": 0, "stop": 60 },
+    ] } ) ).to.be.true
+
+    /* ~30 packets total (10 files × ~3 packets each) + transitions */
+    await new Promise( r => setTimeout( r, 2000 ) )
+
+    channel.close()
+    server.close()
+
+    await finished
+
+    /* should have received data without crashing */
+    expect( receviedpkcount ).to.be.above( 20 )
+  } )
+
+  it( "close channel while file is playing stresses destructor aio cleanup", async function() {
+
+    /*
+    Start playback then immediately close the channel. The soundfilereader
+    destructor must cancel and reap all in-flight aio operations without
+    crashing. Run this multiple times to catch intermittent races.
+    */
+
+    this.timeout( 5000 )
+    this.slow( 3000 )
+
+    for( let attempt = 0; attempt < 10; attempt++ ) {
+      let done
+      const finished = new Promise( r => { done = r } )
+
+      const channel = await prtp.projectrtp.openchannel( { "remote": { "address": "127.0.0.1", "port": 20000, "codec": 0 } }, function( d ) {
+        if( "close" === d.action ) done()
+      } )
+
+      channel.play( { "loop": true, "files": [ { "wav": "/tmp/flat.wav" } ] } )
+
+      /* close after a random short delay (0-50ms) to hit different aio states */
+      await new Promise( r => setTimeout( r, Math.floor( Math.random() * 50 ) ) )
+      channel.close()
+
+      await finished
+    }
   } )
 
   after( async () => {


### PR DESCRIPTION
1. For every aio_read and aio_write we have to ensure we call aio_return just once. We relied on code paths to ensure this - but there could be plenty of oppertunity to get this wrong - so introduce a flag to ensure we call it.
2. DTLS negotiation should be triggered our end - although it is largely no-op with a browser.
3. Tests added to thrash the soundfile object issue a little.