### PR TITLE
Add node getchannel(uuid) + transcribe command for audio tap

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -25,7 +25,12 @@ const channelmap = {
   "play": ( chan, msg ) => chan.play( msg.soup ),
   "record": ( chan, msg ) => chan.record( msg.options ),
   "playrecord": ( chan, msg ) => chan.playrecord( msg.options ),
-  "direction": ( chan, msg ) => chan.direction( msg.options )
+  "direction": ( chan, msg ) => chan.direction( msg.options ),
+  /* "transcribe" carries no channel action of its own - it is consumed by the
+     node's pre hook (the consumer registers a token->channel binding and taps
+     audio itself via getchannel() + createReadStream). Registered here as a
+     no-op so the framework acknowledges it rather than replying "Unknown method". */
+  "transcribe": () => {}
 }
 
 /**
@@ -311,6 +316,18 @@ class rtpnode {
     to our server - this is to, for example, upload a recording to a remote storage
     facility. */
     this._post = this._defaulthandler.bind( this )
+  }
+
+  /**
+   * @summary Look up a live channel object by its uuid.
+   * Channels are created by the node when the server sends an "open" command
+   * and stored in the module-level map. This exposes them to pre/post hooks
+   * (e.g. to tap audio with channel.createReadStream for live transcription).
+   * @param { string } uuid - our channel uuid
+   * @returns { object | undefined } the channel object, or undefined if unknown
+   */
+  getchannel( uuid ) {
+    return channels.get( uuid )
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/projectrtp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A scalable Node addon RTP server",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Summary
- Add `getchannel(uuid)` to the rtp node so its pre/post hooks can reach a live channel object and tap its audio via `channel.createReadStream` — enables live transcription / closed captions in consumers (e.g. babble-rtp), which today only receive plain message objects and have no handle to the channel.
- Register a no-op `transcribe` entry in the node channelmap so a control-server `transcribe` command is acknowledged rather than rejected as "Unknown method" (the actual work is done in the consumer's pre hook).
- Bump to 3.1.0 (additive, minor).

Pure-JS change in `lib/node.js` — no Rust/addon impact.

## Test plan
- [ ] existing suite passes
- [ ] `node.getchannel(uuid)` returns the live channel for an open uuid, `undefined` for an unknown one
- [ ] a `transcribe` command is acknowledged (no "Unknown method" reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)