### PR TITLE
Add channel-client transcribe() + normalise local close() args (3.2.3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -471,6 +471,16 @@ class projectrtp {
       /* ensure we are identicle to the node version of this object */
       chan.openchannel = this.openchannel.bind( this )
 
+      /* The remote (server.js) channel close() takes an options object
+         ({ timeout }); the local Rust napi close() takes an optional reason
+         string and returns a bool. Normalise so callers can hand the same
+         options object to either transport - callmanager calls
+         close( { timeout } ) regardless of whether the channel is local or
+         remote, and the bare object would otherwise fail napi's
+         String conversion. */
+      const napiclose = chan.close.bind( chan )
+      chan.close = ( options ) => napiclose( "string" === typeof options ? options : undefined )
+
       /* Wrap the Rust `createReadStream(opts, cb)` napi method so JS gets a
          standard Node `Readable` — pipeable into fs.createWriteStream,
          WebSocket, fetch bodies, any transform stream, etc.

--- a/lib/server.js
+++ b/lib/server.js
@@ -562,6 +562,26 @@ class channel {
   }
 
   /**
+  @summary Start live transcription on the channel. The command itself is a no-op
+  at the channel level - it is consumed by the node's pre hook, which binds the
+  token to this channel and taps its audio (getchannel() + createReadStream) to
+  stream speech-to-text.
+  @param { Object } options
+  @param { string } options.token - identifier the audio-tap consumer binds to
+  @param { string } [ options.engine ] - STT engine
+  @param { string } [ options.language ] - BCP-47 hint
+  @param { string } [ options.model ] - engine model override
+  @returns { boolean }
+  */
+  transcribe( options ) {
+    this._write( {
+      "channel": "transcribe",
+      options
+    } )
+    return true
+  }
+
+  /**
    * We have received the open confirm message so we should action it
    * @private
    * @param { object } msg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/projectrtp",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
         "uuid": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A scalable Node addon RTP server",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## What

Two small additions plus a patch version bump (3.2.2 → **3.2.3**), ready to publish.

### 1. `lib/server.js` — channel-client `transcribe()`
Adds a `transcribe(options)` method to the control-client channel that writes `{ channel: "transcribe", options }`. This is the **send** counterpart to the existing `lib/node.js` `"transcribe": () => {}` no-op: the node side already acknowledges the command and a consumer (babble-rtp's pre-hook) binds the token to the channel for live captioning — but until now there was no client method to emit it. Lets a control server (babble-sip) start live transcription on a channel by token.

### 2. `index.js` — normalise local-channel `close()` args
The **remote** channel `close(options)` (server.js) reads `options.timeout`; the **local** Rust napi `close(reason: Option<String>)` (`rust/src/channel/facade.rs`) takes an optional reason string. Callers (callmanager) call `close({ timeout })` regardless of transport, which made napi throw `StringExpected` on local channels — surfaced misleadingly as `timed out waiting for channel close` during callmanager's test runs against the real engine.

The local-channel wrapper in `openchannel` already shadows `openchannel`/`createReadStream`; this gives `close` the same treatment, passing a string-or-undefined to the napi method so local and remote channels accept the same options object. JS-only, no Rust rebuild. Production was unaffected (it only uses remote channels); this is test-path hygiene + API consistency.

## Why now
Unblocks babble-sip's live-transcribe trigger (needs the client `transcribe()`), and clears the close() error spam when callmanager runs its suite against projectrtp 3.x.

## Notes
- No Rust changes; the published JS picks both up.
- Downstream: callmanager 3.7.32 already peers `@babblevoice/projectrtp ^3.2.2`, so it'll pick up 3.2.3 on update; babble-sip then bumps to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)