### PR TITLE
Fix rtp_open_count leak on mixed-channel last-resort teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A scalable Node addon RTP server",
   "main": "index.js",
   "directories": {

--- a/rust/src/channel/actor.rs
+++ b/rust/src/channel/actor.rs
@@ -385,7 +385,15 @@ async fn run(
     let (state, subs) = match &mut mode {
         Mode::Local { state, subs } => (state, subs),
         Mode::Mixed { .. } => {
-            // Last-resort: emit a minimal Close event without stats.
+            // Last-resort: the defensive `mix.remove(id)` above timed out or
+            // returned None, so we never transitioned back to Local. Emit a
+            // minimal Close event without stats — but unregister from the
+            // registry FIRST (same ordering rule as the Local path below).
+            // Without this, a mixed channel whose mixer was contended at
+            // teardown stays in CHANNEL_REGISTRY forever and leaks
+            // `stats.channel.current` (rtp_open_count) even though the client
+            // saw a clean Close.
+            super::facade::unregister_channel(id);
             events.post(Event::Close { reason, stats: ChannelStats::default() });
             drop(self_cmd);
             return;


### PR DESCRIPTION
## Problem

Intermittent, cumulative RTP channel leak observed in the babble-sip multinode/fifo-pickup test suite: `rtp_open_count` on a babble-rtp node never drains back to zero after the calls end.

It is **engine-side**: the client and the test proxy (fakeloadbalancer) both saw a clean Close — their channel bookkeeping (`currentchannels`, matched by open-cmd vs close-action id) drained to 0 — while the engine node's `/metrics` still reported `rtp_open_count: 4`. Client clean + engine dirty = the engine acknowledged closes it didn't fully process.

## Root cause

`rust/src/channel/actor.rs` has two channel-teardown exit paths:

- **`Mode::Local`** (normal) — calls `facade::unregister_channel(id)` before posting the `Close` event. ✅
- **`Mode::Mixed` last-resort** — reached when the defensive `mix.remove(id)` above **times out (100ms) or returns None** under mixer contention during a *mixed* teardown. It posted `Close` but **never called `unregister_channel`**. ❌

The channel `Handle` therefore stayed in `CHANNEL_REGISTRY` forever. Since `stats.channel.current` (`rtp_open_count`) reads the registry length (`active_channel_count()`), the count leaked.

This explains every symptom:
- **engine-side** — client/proxy bookkeeping is clean, only the engine gauge is wrong
- **mix-only** — only mixed teardowns can reach this branch
- **intermittent 1-vs-N** — it's a 100ms race on `mix.remove(id)`
- **cumulative** — the registry is never cleaned

## Fix

Call `super::facade::unregister_channel(id)` in the `Mode::Mixed` branch too, before posting `Close`, matching the ordering rule the `Local` path documents.

Patch version bump 3.2.3 → 3.2.4.

## Verification

- `cargo build --release` clean.
- Confirmed via grep that these are the only two `Event::Close` posts in the actor; the other already unregisters.
- End-to-end: publish 3.2.4, rebuild the babble-rtp test nodes, and the babble-sip suite's `waitforidle` rtp-leak detector should report 0 orphaned channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)