### PR TITLE
Fix G.722/G.711 mixed recording half-rate + flaky rtpchannel suite (3.2.5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -436,7 +436,15 @@ class projectrtp {
             if( d.action ) chan.em.emit( d.action, d )
           }
         } catch ( e ) {
-          console.trace( e )
+          /* A listener (e.g. a test assertion) threw. Don't silently swallow
+             it — that hides real failures and makes them surface only as
+             unrelated timeouts. Re-raise asynchronously so it becomes a
+             visible uncaughtException (Node's default for a throwing event
+             listener) instead of being lost. We rethrow rather than emit
+             "error" so a channel without an "error" listener still fails
+             loudly. Deferring to setImmediate keeps the napi callback that
+             delivered this event from unwinding through the throw. */
+          setImmediate( () => { throw e } )
         }
       } )
       /* Build chan.local from the Rust napi-class getters (port/ssrc/icepwd/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.2.3",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/projectrtp",
-      "version": "3.2.3",
+      "version": "3.2.5",
       "license": "MIT",
       "dependencies": {
         "uuid": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/projectrtp",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "A scalable Node addon RTP server",
   "main": "index.js",
   "directories": {

--- a/rust/src/channel/actor.rs
+++ b/rust/src/channel/actor.rs
@@ -578,6 +578,7 @@ async fn handle_command_local(
             state.set_remote_addr(cfg.addr);
             state.ticks_without_rtp = 0;
             state.remote_pt = cfg.payload_type;
+            state.codecx.set_negotiated_pt(cfg.payload_type);
             if let Some(pt) = cfg.rfc2833_payload_type {
                 state.rfc2833_pt = pt;
             }

--- a/rust/src/channel/mixer.rs
+++ b/rust/src/channel/mixer.rs
@@ -1019,6 +1019,7 @@ async fn apply_forwarded(m: &mut Member, cmd: Command) {
         Command::Remote { cfg, ack } => {
             m.state.set_remote_addr(cfg.addr);
             m.state.remote_pt = cfg.payload_type;
+            m.state.codecx.set_negotiated_pt(cfg.payload_type);
             if let Some(pt) = cfg.rfc2833_payload_type {
                 m.state.rfc2833_pt = pt;
             }

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -213,6 +213,12 @@ pub struct CodecBundle {
     /// Slot 0 is the local side's configured iLBC wire PT; slot 1 is the
     /// mix peer's. Static PT 97 is always accepted.
     ilbc_pts: [u8; 2],
+    /// Negotiated (SDP) RTP payload type for this channel, set at remote
+    /// config — known before the first inbound packet decodes. Lets
+    /// `is_wideband()` / `native_samplerate()` report wideband for a G.722
+    /// channel even when no packet has set `wire_pt` yet (e.g. a `record`
+    /// issued before media starts). 255 = not yet negotiated.
+    negotiated_pt: u8,
 
     // ---- Input (one of these is set by a `feed_*` call) ----
     /// PT of the wire bytes currently held, or 255 if no wire input.
@@ -244,6 +250,7 @@ impl CodecBundle {
             ilbc_encoder: None,
             ilbc_decoder: None,
             ilbc_pts: [97, 97],
+            negotiated_pt: 255,
             wire_pt: 255,
             wire_bytes: Vec::with_capacity(320),
             narrowband_8k: None,
@@ -257,6 +264,10 @@ impl CodecBundle {
 
     pub fn set_local_ilbc_pt(&mut self, pt: u8) { self.ilbc_pts[0] = pt; }
     pub fn set_peer_ilbc_pt(&mut self, pt: u8) { self.ilbc_pts[1] = pt; }
+
+    /// Record the negotiated (SDP) RTP payload type. Drives the wideband
+    /// classification before any packet has been decoded.
+    pub fn set_negotiated_pt(&mut self, pt: u8) { self.negotiated_pt = pt; }
 
     fn is_ilbc_pt(&self, pt: u8) -> bool {
         pt == 97 || pt == self.ilbc_pts[0] || pt == self.ilbc_pts[1]
@@ -310,10 +321,15 @@ impl CodecBundle {
         self.wideband_16k = Some(samples.to_vec());
     }
 
-    /// True if the current wire codec is wideband (G.722, PT 9). Used to pick
-    /// the channel's native PCM rate for recordings / readers.
+    /// True if this channel is wideband (G.722, PT 9). Used to pick the
+    /// channel's native PCM rate for recordings / readers. Considers both
+    /// the live wire codec and the negotiated SDP codec, so a recorder
+    /// opened before the first inbound G.722 packet is still stamped at
+    /// 16 kHz — matching the wideband frames the feed path writes once
+    /// media flows. Without the negotiated fallback the WAV header (8 kHz)
+    /// and the 16 kHz audio disagreed and playback ran at half speed.
     pub fn is_wideband(&self) -> bool {
-        self.wire_pt == 9
+        self.wire_pt == 9 || self.negotiated_pt == 9
     }
 
     /// The channel's native PCM sample rate inferred from the wire codec:

--- a/test/interface/projectrtpchannel.js
+++ b/test/interface/projectrtpchannel.js
@@ -582,7 +582,7 @@ describe( "rtpchannel", function() {
     } )
   } )
 
-  it( "create channel and check event emitter", async () => {
+  it( "create channel and check event emitter", async function() {
 
     this.timeout( 2000 )
     this.slow( 2000 )

--- a/test/interface/projectrtpmix.js
+++ b/test/interface/projectrtpmix.js
@@ -671,6 +671,63 @@ describe( "channel mix", function() {
   } )
 
 
+  it( "mix 2 channels - record on the g722 leg is stamped 16k (not half-rate)", async function() {
+
+    /* Regression: a record requested on a G.722 (wideband) leg before the
+       first inbound packet decoded was stamped 8 kHz in the WAV header while
+       the feed path wrote true 16 kHz frames, so the recording played back at
+       half speed. The recorder rate must follow the negotiated codec. */
+
+    this.timeout( 3000 )
+    this.slow( 2000 )
+
+    const endpointa = dgram.createSocket( "udp4" )   // pcmu (711) leg
+    const endpointb = dgram.createSocket( "udp4" )   // g722 leg
+
+    await new Promise( ( r ) => { endpointa.on( "listening", r ); endpointa.bind() } )
+    await new Promise( ( r ) => { endpointb.on( "listening", r ); endpointb.bind() } )
+
+    let done
+    const finished = new Promise( ( r ) => { done = r } )
+
+    const channela = await projectrtp.openchannel( { "remote": { "address": "127.0.0.1", "port": endpointa.address().port, "codec": 0 } }, function( d ) {
+      if( "close" === d.action ) channelb.close()
+    } )
+    const channelb = await projectrtp.openchannel( { "remote": { "address": "127.0.0.1", "port": endpointb.address().port, "codec": 9 } }, function( d ) {
+      if( "close" === d.action ) done()
+    } )
+
+    expect( channela.mix( channelb ) ).to.be.true
+
+    const recfile = "/tmp/g722legrecording.wav"
+    try { await fs.unlink( recfile ) } catch( e ) { /* may not exist */ }
+
+    /* Record on the g722 leg, before any media flows (typical SIP ordering). */
+    channelb.record( { "file": recfile } )
+
+    const g722pl = Buffer.alloc( 160 ).fill( 0x40 )
+    for( let i = 0; 50 > i; i++ ) {
+      sendpk( i, i, channela.local.port, endpointa )
+      sendpk( i, i, channelb.local.port, endpointb, g722pl, 9 )
+    }
+
+    await new Promise( ( resolve ) => { setTimeout( () => resolve(), 1500 ) } )
+
+    channela.close()
+    endpointa.close()
+    endpointb.close()
+
+    await finished
+
+    /* The WAV header (offset 24, little-endian u32) must read 16000. */
+    const header = await fs.readFile( recfile )
+    const samplerate = header.readUInt32LE( 24 )
+    expect( samplerate ).to.equal( 16000 )
+    await fs.unlink( recfile )
+
+  } )
+
+
   it( "playback prompt then mix 2 channels - pcmu <-> g722 with recording", async function() {
 
     this.timeout( 3000 )


### PR DESCRIPTION
## Summary

Two independent bug fixes plus a patch version bump to **3.2.5** (ready for npm).

### 1. G.722/G.711 mixed recording played back at half rate (the reported bug)
When one leg is G.722 (16 kHz) and the other G.711 (8 kHz), a recording on the **G.722 leg** played back at half speed.

**Cause:** the recorder's WAV sample rate was derived from `codecx.is_wideband()`, which only inspected the *live wire* payload type. That's still `255` when `record` is issued before the first inbound RTP packet decodes (the normal SIP ordering), so a G.722 channel was misclassified as narrowband and the file stamped 8 kHz — while the per-tick feed path wrote true 16 kHz wideband frames. 16 kHz audio in an 8 kHz container = half-speed playback.

**Fix:** `CodecBundle` now also tracks the **negotiated (SDP) payload type**, set at remote-config (known before any packet). `is_wideband()`/`native_samplerate()` consider it, so the stamp and the fed audio agree from the first frame. Added a regression test that records on the G.722 leg and asserts the WAV is stamped 16 kHz.

### 2. Consistently-failing `rtpchannel` test suite (12 tests)
The full `npm test` run consistently failed all 12 `rtpchannel` tests with `done() called multiple times / Timeout 2000ms`, even though the tests actually pass in isolation.

**Cause (traced via mocha timer instrumentation):** the `"check event emitter"` test is an **arrow function** calling `this.timeout(2000)`. In an arrow, `this` is the enclosing `describe` **Suite**, and mocha 11's `Suite.timeout()` re-arms the timeout timer of *every* test in the suite. That re-armed all 12 already-passed sibling tests; their stale 2000 ms timers fired 2 s later and retroactively flipped them to failed. Only visible in the full suite, where the process stays alive long enough for the timers to fire (in isolation it exits first).

**Fix:** switched the test to a regular `function()` so `this.timeout()` binds to the test, not the suite. (Swept the whole `test/` tree — this was the only offending case.)

### 3. Harness honesty
`index.js` swallowed throws from the channel event callback via `console.trace`, so a failed assertion inside a `close`/`record`/`play` handler surfaced only as an unrelated timeout. It now re-raises asynchronously (`setImmediate`) so the real error becomes a visible `uncaughtException`.

## Verification
- `npm test`: **143 passing, 6 pending, 0 failing**.
- `cargo test --lib` (single-threaded): 77 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)