### PR TITLE
ci: bump workflow actions to latest majors

### DIFF
--- a/.github/workflows/buildimage.yaml
+++ b/.github/workflows/buildimage.yaml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: ourdockertags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             docker.io/tinpotnick/projectrtp
@@ -45,13 +45,13 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout (with libilbc submodule)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -34,7 +34,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Bumps the pinned GitHub Action major versions in this repo's workflow(s) to the current latest majors. Upgrade-only and idempotent — only version tokens change, structure untouched.

**Bumps:**
- `actions/checkout` v5 → v6  (`.github/workflows/buildimage.yaml`)
- `docker/setup-qemu-action` v3 → v4  (`.github/workflows/buildimage.yaml`)
- `docker/setup-buildx-action` v3 → v4  (`.github/workflows/buildimage.yaml`)
- `docker/metadata-action` v5 → v6  (`.github/workflows/buildimage.yaml`)
- `docker/login-action` v3 → v4  (`.github/workflows/buildimage.yaml`)
- `docker/build-push-action` v6 → v7  (`.github/workflows/buildimage.yaml`)
- `actions/checkout` v5 → v6  (`.github/workflows/rust.yml`)
- `actions/cache` v4 → v5  (`.github/workflows/rust.yml`)

Part of an org-wide pass bringing every build workflow up to the latest action versions (Turnstile handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
