### PR TITLE
Fix Build CI: fetch libilbc submodule before Docker build

### DIFF
--- a/.github/workflows/buildimage.yaml
+++ b/.github/workflows/buildimage.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Problem

The **Build** workflow (`buildimage.yaml`) has been failing on every push to `main` for weeks. The Docker build dies at the cmake step:

```
CMake Error: The source directory "/src/libilbc" does not appear to contain CMakeLists.txt.
...
ld: cannot find -l:libilbc.so.3: No such file or directory
error: could not compile `projectrtp` (lib) due to 1 previous error
```

## Root cause

`libilbc` is a git submodule (`.gitmodules`: `path = libilbc`, `url = https://github.com/TimothyGu/libilbc`). The Dockerfile does `COPY libilbc/ /src/libilbc/` and runs cmake on it to build `libilbc.so.3`.

The checkout step used `actions/checkout@v5` with no `submodules:` setting. `actions/checkout` does **not** fetch submodules by default (any version), so `libilbc/` is empty in the build context → cmake finds no `CMakeLists.txt` → `libilbc.so.3` is never built → the Rust cdylib fails to link.

## Fix

Add `submodules: recursive` to the checkout step so the build context contains the libilbc source. `rust.yml` already does this. The submodule is a public repo, so no extra token is needed.

This is independent of the rustfmt drift failing the Rust CI job (handled in a separate PR), and is not related to the action-version-bump PRs — `checkout@v5` and `@v6` both skip submodules by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)