### PR TITLE
Apply cargo fmt across the rust crate

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -13,7 +13,11 @@ fn link_native(name: &str, fallback_versioned_soname: &str) {
     // `/usr/local/*` covers the case where the library was built from
     // source in the Docker image (as libilbc is) and installed there.
     let search_paths = [
-        "/usr/lib64", "/usr/lib", "/lib", "/usr/local/lib", "/usr/local/lib64",
+        "/usr/lib64",
+        "/usr/lib",
+        "/lib",
+        "/usr/local/lib",
+        "/usr/local/lib64",
     ];
     let unversioned = format!("lib{}.so", name);
     let has_unversioned = search_paths

--- a/rust/src/channel/actor.rs
+++ b/rust/src/channel/actor.rs
@@ -15,8 +15,8 @@
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::net::UdpSocket;
@@ -50,7 +50,9 @@ impl ChannelStats {
     /// from the C++ codebase (originally borrowed from FreeSWITCH).
     /// Returns 0.0 when no packets were received.
     pub fn mos(&self) -> f64 {
-        if self.in_count == 0 { return 0.0; }
+        if self.in_count == 0 {
+            return 0.0;
+        }
         let r = ((self.in_count - self.in_skip) as f64 / self.in_count as f64) * 100.0;
         let r = r.clamp(0.0, 100.0);
         1.0 + (0.035 * r) + (0.000007 * r * (r - 60.0) * (100.0 - r))
@@ -59,18 +61,39 @@ impl ChannelStats {
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    Close { reason: String, stats: ChannelStats },
-    Play { state: PlayState, reason: Option<String> },
-    Record { state: RecordState, reason: Option<String>, file: Option<String>, filesize: Option<u64> },
-    TelephoneEvent { digit: char },
-    Mix { state: String },
+    Close {
+        reason: String,
+        stats: ChannelStats,
+    },
+    Play {
+        state: PlayState,
+        reason: Option<String>,
+    },
+    Record {
+        state: RecordState,
+        reason: Option<String>,
+        file: Option<String>,
+        filesize: Option<u64>,
+    },
+    TelephoneEvent {
+        digit: char,
+    },
+    Mix {
+        state: String,
+    },
 }
 
 #[derive(Debug, Clone)]
-pub enum PlayState { Start, End }
+pub enum PlayState {
+    Start,
+    End,
+}
 
 #[derive(Debug, Clone)]
-pub enum RecordState { Recording, Finished }
+pub enum RecordState {
+    Recording,
+    Finished,
+}
 
 /// Abstract sink for events — a trait so tests can capture events into a
 /// channel and the napi facade can forward into a ThreadsafeFunction.
@@ -95,7 +118,10 @@ pub struct SpawnConfig {
 pub async fn spawn(cfg: SpawnConfig) -> std::io::Result<Handle> {
     let rtp_sock = UdpSocket::bind(cfg.bind_addr).await?;
     let local_addr = rtp_sock.local_addr()?;
-    let rtcp_port = local_addr.port().checked_add(1).unwrap_or(local_addr.port());
+    let rtcp_port = local_addr
+        .port()
+        .checked_add(1)
+        .unwrap_or(local_addr.port());
     let rtcp_sock = UdpSocket::bind(SocketAddr::new(local_addr.ip(), rtcp_port)).await?;
     spawn_with_sockets(cfg, rtp_sock, rtcp_sock, local_addr)
 }
@@ -131,7 +157,10 @@ pub fn spawn_with_sockets(
     let events = cfg.events;
     let handle_cmd = tx.clone();
     tokio::spawn(async move { run(Box::new(state), rx, events, handle_cmd).await });
-    Ok(Handle { id: cfg.id, cmd: tx })
+    Ok(Handle {
+        id: cfg.id,
+        cmd: tx,
+    })
 }
 
 /// Upper bound on the pre-buffer queue — cap is drop-oldest. Sized to hold
@@ -223,7 +252,10 @@ pub(super) async fn activate_pending_recorder(
             if !drained.is_empty() {
                 let frame = if rec.num_channels() == 2 {
                     let mut inter = Vec::with_capacity(drained.len() * 2);
-                    for s in &drained { inter.push(*s); inter.push(*s); }
+                    for s in &drained {
+                        inter.push(*s);
+                        inter.push(*s);
+                    }
                     inter
                 } else {
                     drained
@@ -277,7 +309,10 @@ async fn run(
     self_cmd: mpsc::Sender<Command>,
 ) {
     let id = initial_state.id;
-    let mut mode = Mode::Local { state: initial_state, subs: Subsystems::default() };
+    let mut mode = Mode::Local {
+        state: initial_state,
+        subs: Subsystems::default(),
+    };
     let mut ticker = interval(Duration::from_millis(TICK_MS));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -314,9 +349,14 @@ async fn run(
                         // emitted yet, so nothing to finish — just drop.
                         subs_out.pending_recorder = None;
                         subs_out.prebuffer.clear();
-                        match mix.add(Box::new(Member::new(state_out, subs_out, events.clone()))).await {
+                        match mix
+                            .add(Box::new(Member::new(state_out, subs_out, events.clone())))
+                            .await
+                        {
                             Ok(()) => {
-                                events.post(Event::Mix { state: "start".to_string() });
+                                events.post(Event::Mix {
+                                    state: "start".to_string(),
+                                });
                                 mode = Mode::Mixed { mix };
                                 let _ = ack.send(());
                             }
@@ -338,14 +378,18 @@ async fn run(
                     Some(Command::Close { reason }) => {
                         if let Some(member) = mix.remove(id).await {
                             restore_local(&mut mode, member);
-                            events.post(Event::Mix { state: "finished".to_string() });
+                            events.post(Event::Mix {
+                                state: "finished".to_string(),
+                            });
                         }
                         closing = Some(reason);
                     }
                     Some(Command::LeaveMix { ack }) => {
                         if let Some(member) = mix.remove(id).await {
                             restore_local(&mut mode, member);
-                            events.post(Event::Mix { state: "finished".to_string() });
+                            events.post(Event::Mix {
+                                state: "finished".to_string(),
+                            });
                         }
                         let _ = ack.send(());
                     }
@@ -355,7 +399,9 @@ async fn run(
                         // `mix/start` event so JS sees one per mix() call.
                         // Different-group migration isn't supported yet.
                         if new_mix.id == mix.id {
-                            events.post(Event::Mix { state: "start".to_string() });
+                            events.post(Event::Mix {
+                                state: "start".to_string(),
+                            });
                         }
                         let _ = ack.send(());
                     }
@@ -376,9 +422,13 @@ async fn run(
     // try to reclaim state for the stats payload. Use a timeout so a dead
     // mixer doesn't strand the actor.
     if let Mode::Mixed { mix } = &mode {
-        if let Ok(Some(member)) = tokio::time::timeout(Duration::from_millis(100), mix.remove(id)).await {
+        if let Ok(Some(member)) =
+            tokio::time::timeout(Duration::from_millis(100), mix.remove(id)).await
+        {
             restore_local(&mut mode, member);
-            events.post(Event::Mix { state: "finished".to_string() });
+            events.post(Event::Mix {
+                state: "finished".to_string(),
+            });
         }
     }
 
@@ -394,7 +444,10 @@ async fn run(
             // `stats.channel.current` (rtp_open_count) even though the client
             // saw a clean Close.
             super::facade::unregister_channel(id);
-            events.post(Event::Close { reason, stats: ChannelStats::default() });
+            events.post(Event::Close {
+                reason,
+                stats: ChannelStats::default(),
+            });
             drop(self_cmd);
             return;
         }
@@ -462,7 +515,9 @@ async fn run(
         in_skip: state.in_skip,
         out_count: state.out_count,
     };
-    state.close_info = Some(CloseInfo { reason: reason.clone() });
+    state.close_info = Some(CloseInfo {
+        reason: reason.clone(),
+    });
     // Order matters: `unregister_channel` decrements the registry BEFORE
     // the Close event is posted. Otherwise a JS `afterEach` that asserts
     // `stats.channel.current === 0` races the TSFN queue — the callback
@@ -480,7 +535,12 @@ fn take_local(mode: &mut Mode) -> (Box<ChannelState>, Subsystems) {
     // Swap out with a temporary Mixed placeholder — we'll overwrite mode
     // right after. The placeholder MixHandle is never used because the
     // caller transitions mode before any further command handling runs.
-    let placeholder = Mode::Mixed { mix: MixHandle { id: 0, cmd: mpsc::channel(1).0 } };
+    let placeholder = Mode::Mixed {
+        mix: MixHandle {
+            id: 0,
+            cmd: mpsc::channel(1).0,
+        },
+    };
     let taken = std::mem::replace(mode, placeholder);
     match taken {
         Mode::Local { state, subs } => (state, subs),
@@ -622,7 +682,10 @@ async fn handle_command_local(
             if subs.player.is_some() {
                 subs.player = None;
                 subs.bargein = None;
-                events.post(Event::Play { state: PlayState::End, reason: Some("replaced".into()) });
+                events.post(Event::Play {
+                    state: PlayState::End,
+                    reason: Some("replaced".into()),
+                });
             }
             // A bare `play` supersedes any `playrecord` pending recorder.
             // No Recording event was emitted for it yet (activation hasn't
@@ -630,7 +693,10 @@ async fn handle_command_local(
             subs.pending_recorder = None;
             subs.prebuffer.clear();
             subs.player = Some(Player::new(cfg));
-            events.post(Event::Play { state: PlayState::Start, reason: Some("new".into()) });
+            events.post(Event::Play {
+                state: PlayState::Start,
+                reason: Some("new".into()),
+            });
             let _ = ack.send(());
             LocalOutcome::Continue
         }
@@ -649,7 +715,11 @@ async fn handle_command_local(
             // If an existing recorder at the same path is paused, resume it
             // instead of replacing it — preserves the WAV so both segments
             // end up in one file.
-            if let Some(rec) = subs.recorders.iter_mut().find(|r| r.file() == cfg.file && r.state() == RecorderState::Paused) {
+            if let Some(rec) = subs
+                .recorders
+                .iter_mut()
+                .find(|r| r.file() == cfg.file && r.state() == RecorderState::Paused)
+            {
                 rec.resume();
                 events.post(Event::Record {
                     state: RecordState::Recording,
@@ -658,45 +728,48 @@ async fn handle_command_local(
                     filesize: None,
                 });
             } else {
-            match Recorder::open(cfg.clone()).await {
-                Ok(rec) => {
-                    if let Some(idx) = subs.recorders.iter().position(|r| r.file() == rec.file()) {
-                        let mut old = subs.recorders.remove(idx);
-                        let size = old.file_size();
-                        old.close(FinishReason::ChannelClosed);
+                match Recorder::open(cfg.clone()).await {
+                    Ok(rec) => {
+                        if let Some(idx) =
+                            subs.recorders.iter().position(|r| r.file() == rec.file())
+                        {
+                            let mut old = subs.recorders.remove(idx);
+                            let size = old.file_size();
+                            old.close(FinishReason::ChannelClosed);
+                            events.post(Event::Record {
+                                state: RecordState::Finished,
+                                reason: Some("channelclosed".into()),
+                                file: Some(file_str.clone()),
+                                filesize: Some(size),
+                            });
+                        }
+                        subs.recorders.push(rec);
+                        if !is_gated {
+                            events.post(Event::Record {
+                                state: RecordState::Recording,
+                                reason: None,
+                                file: Some(file_str),
+                                filesize: None,
+                            });
+                        }
+                    }
+                    Err(e) => {
                         events.post(Event::Record {
                             state: RecordState::Finished,
-                            reason: Some("channelclosed".into()),
-                            file: Some(file_str.clone()),
-                            filesize: Some(size),
-                        });
-                    }
-                    subs.recorders.push(rec);
-                    if !is_gated {
-                        events.post(Event::Record {
-                            state: RecordState::Recording,
-                            reason: None,
+                            reason: Some(format!("open-failed: {e}")),
                             file: Some(file_str),
                             filesize: None,
                         });
                     }
                 }
-                Err(e) => {
-                    events.post(Event::Record {
-                        state: RecordState::Finished,
-                        reason: Some(format!("open-failed: {e}")),
-                        file: Some(file_str),
-                        filesize: None,
-                    });
-                }
-            }
             }
             let _ = ack.send(());
             LocalOutcome::Continue
         }
 
         Command::CreateReadStream { id, cfg, sender } => {
-            subs.readers.push(super::audio_reader::AudioReader::new(id, cfg, sender));
+            subs.readers
+                .push(super::audio_reader::AudioReader::new(id, cfg, sender));
             LocalOutcome::Continue
         }
 
@@ -713,7 +786,10 @@ async fn handle_command_local(
             if subs.player.is_some() {
                 subs.player = None;
                 subs.bargein = None;
-                events.post(Event::Play { state: PlayState::End, reason: Some("replaced".into()) });
+                events.post(Event::Play {
+                    state: PlayState::End,
+                    reason: Some("replaced".into()),
+                });
             }
             subs.pending_recorder = None;
             subs.prebuffer.clear();
@@ -723,7 +799,9 @@ async fn handle_command_local(
 
         Command::DestroyWriteStream { id } => {
             if let Some(w) = subs.writer.as_ref() {
-                if w.id() == id { subs.writer = None; }
+                if w.id() == id {
+                    subs.writer = None;
+                }
             }
             LocalOutcome::Continue
         }
@@ -746,7 +824,11 @@ async fn handle_command_local(
 
         Command::RecordSetPaused { file, paused } => {
             if let Some(rec) = subs.recorders.iter_mut().find(|r| r.file() == file) {
-                if paused { rec.pause(); } else { rec.resume(); }
+                if paused {
+                    rec.pause();
+                } else {
+                    rec.resume();
+                }
             }
             LocalOutcome::Continue
         }
@@ -755,7 +837,10 @@ async fn handle_command_local(
             if subs.player.is_some() {
                 subs.player = None;
                 subs.bargein = None;
-                events.post(Event::Play { state: PlayState::End, reason: Some("replaced".into()) });
+                events.post(Event::Play {
+                    state: PlayState::End,
+                    reason: Some("replaced".into()),
+                });
             }
             // Supersede any previously-queued pending recorder — its file was
             // never opened, so no Record event is owed (matches C++: no file
@@ -765,7 +850,10 @@ async fn handle_command_local(
             subs.prebuffer.clear();
 
             subs.player = Some(Player::new(cfg.player));
-            events.post(Event::Play { state: PlayState::Start, reason: Some("new".into()) });
+            events.post(Event::Play {
+                state: PlayState::Start,
+                reason: Some("new".into()),
+            });
 
             if cfg.interrupt {
                 if let Some(threshold) = cfg.bargein_power {
@@ -806,19 +894,27 @@ async fn handle_command_local(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::commands::Direction;
+    use super::*;
     use std::sync::Mutex;
     use tokio::sync::mpsc as tmpsc;
 
-    struct TestSink { tx: tmpsc::UnboundedSender<Event> }
+    struct TestSink {
+        tx: tmpsc::UnboundedSender<Event>,
+    }
     impl EventSink for TestSink {
-        fn post(&self, ev: Event) { let _ = self.tx.send(ev); }
+        fn post(&self, ev: Event) {
+            let _ = self.tx.send(ev);
+        }
     }
 
-    struct CountingSink { count: Mutex<Vec<Event>> }
+    struct CountingSink {
+        count: Mutex<Vec<Event>>,
+    }
     impl EventSink for CountingSink {
-        fn post(&self, ev: Event) { self.count.lock().unwrap().push(ev); }
+        fn post(&self, ev: Event) {
+            self.count.lock().unwrap().push(ev);
+        }
     }
 
     #[tokio::test]
@@ -833,12 +929,16 @@ mod tests {
             events: sink,
             port_reservation: None,
             local_icepwd: String::new(),
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
 
         handle.close("test").await;
 
         let ev = tokio::time::timeout(Duration::from_millis(500), rx.recv())
-            .await.expect("no close event").expect("stream ended");
+            .await
+            .expect("no close event")
+            .expect("stream ended");
         match ev {
             Event::Close { reason, .. } => assert_eq!(reason, "test"),
             other => panic!("unexpected event: {:?}", other),
@@ -847,7 +947,9 @@ mod tests {
 
     #[tokio::test]
     async fn direction_command_mutates_state_via_tick_observable() {
-        let sink = Arc::new(CountingSink { count: Mutex::new(Vec::new()) });
+        let sink = Arc::new(CountingSink {
+            count: Mutex::new(Vec::new()),
+        });
         let handle = spawn(SpawnConfig {
             id: 1,
             bind_addr: "127.0.0.1:0".parse().unwrap(),
@@ -855,9 +957,16 @@ mod tests {
             events: sink.clone(),
             port_reservation: None,
             local_icepwd: String::new(),
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
 
-        handle.direction(Direction { send: false, recv: false }).await;
+        handle
+            .direction(Direction {
+                send: false,
+                recv: false,
+            })
+            .await;
         handle.echo(true).await;
         handle.dtmf("1#").await;
 
@@ -882,17 +991,28 @@ mod tests {
             events: sink,
             port_reservation: None,
             local_icepwd: String::new(),
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
 
-        handle.play(crate::channel::player::SoundSoupSpec {
-            files: vec![],
-            overall_loops: None,
-            interrupt: false,
-        }).await.unwrap();
+        handle
+            .play(crate::channel::player::SoundSoupSpec {
+                files: vec![],
+                overall_loops: None,
+                interrupt: false,
+            })
+            .await
+            .unwrap();
 
         let mut saw_play = false;
         while let Ok(Some(ev)) = tokio::time::timeout(Duration::from_millis(100), rx.recv()).await {
-            if matches!(ev, Event::Play { state: PlayState::Start, .. }) {
+            if matches!(
+                ev,
+                Event::Play {
+                    state: PlayState::Start,
+                    ..
+                }
+            ) {
                 saw_play = true;
                 break;
             }
@@ -936,7 +1056,10 @@ mod tests {
 
         let mut events: Vec<Event> = Vec::new();
         let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder { cfg, file_str: file_str.clone() });
+        subs.pending_recorder = Some(PendingRecorder {
+            cfg,
+            file_str: file_str.clone(),
+        });
         subs.prebuffer.extend(vec![500i16; 800]);
 
         let activated = activate_pending_recorder(&mut subs, &mut events).await;
@@ -946,9 +1069,13 @@ mod tests {
         assert_eq!(subs.recorders.len(), 1);
 
         // Recording event fires (recorder is not gated).
-        assert!(events.iter().any(|e| matches!(e,
-            Event::Record { state: RecordState::Recording, file: Some(f), .. } if f == &file_str
-        )), "expected Record::Recording event, got {:?}", events);
+        assert!(
+            events.iter().any(|e| matches!(e,
+                Event::Record { state: RecordState::Recording, file: Some(f), .. } if f == &file_str
+            )),
+            "expected Record::Recording event, got {:?}",
+            events
+        );
 
         // Close and verify the file has the 800 pre-buffer samples.
         let mut rec = subs.recorders.pop().unwrap();
@@ -967,7 +1094,10 @@ mod tests {
 
         let mut events: Vec<Event> = Vec::new();
         let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder { cfg, file_str: file_str.clone() });
+        subs.pending_recorder = Some(PendingRecorder {
+            cfg,
+            file_str: file_str.clone(),
+        });
         subs.prebuffer.extend(vec![100i16; 400]);
 
         assert!(activate_pending_recorder(&mut subs, &mut events).await);
@@ -989,13 +1119,20 @@ mod tests {
 
         let mut events: Vec<Event> = Vec::new();
         let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder { cfg, file_str: file_str.clone() });
+        subs.pending_recorder = Some(PendingRecorder {
+            cfg,
+            file_str: file_str.clone(),
+        });
 
         assert!(activate_pending_recorder(&mut subs, &mut events).await);
         // Gated recorders don't emit Recording until the gate opens; the
         // helper itself should not queue one at activation time.
-        assert!(!events.iter().any(|e| matches!(e,
-            Event::Record { state: RecordState::Recording, .. }
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            Event::Record {
+                state: RecordState::Recording,
+                ..
+            }
         )));
         let mut rec = subs.recorders.pop().unwrap();
         rec.close(FinishReason::Completed);
@@ -1026,7 +1163,9 @@ mod tests {
             events: sink,
             port_reservation: None,
             local_icepwd: String::new(),
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
 
         let rec_cfg = test_recorder_cfg("actor_playrecord_defer.wav");
         let rec_path = rec_cfg.file.clone();
@@ -1056,31 +1195,66 @@ mod tests {
             observed.push(ev);
         }
 
-        let play_start_idx = observed.iter().position(|e|
-            matches!(e, Event::Play { state: PlayState::Start, .. })
-        ).expect("expected Play::Start");
-        let play_end_idx = observed.iter().position(|e|
-            matches!(e, Event::Play { state: PlayState::End, .. })
-        ).expect("expected Play::End after empty soup");
-        let rec_rec_idx = observed.iter().position(|e|
-            matches!(e, Event::Record { state: RecordState::Recording, file: Some(f), .. }
+        let play_start_idx = observed
+            .iter()
+            .position(|e| {
+                matches!(
+                    e,
+                    Event::Play {
+                        state: PlayState::Start,
+                        ..
+                    }
+                )
+            })
+            .expect("expected Play::Start");
+        let play_end_idx = observed
+            .iter()
+            .position(|e| {
+                matches!(
+                    e,
+                    Event::Play {
+                        state: PlayState::End,
+                        ..
+                    }
+                )
+            })
+            .expect("expected Play::End after empty soup");
+        let rec_rec_idx = observed
+            .iter()
+            .position(|e| {
+                matches!(e, Event::Record { state: RecordState::Recording, file: Some(f), .. }
                       if f == &rec_path_str)
-        ).expect("expected Record::Recording after play ends");
+            })
+            .expect("expected Record::Recording after play ends");
 
-        assert!(play_start_idx < play_end_idx,
-            "Play::Start must precede Play::End: {:?}", observed);
-        assert!(play_end_idx < rec_rec_idx,
-            "Play::End must precede Record::Recording (activation order): {:?}", observed);
+        assert!(
+            play_start_idx < play_end_idx,
+            "Play::Start must precede Play::End: {:?}",
+            observed
+        );
+        assert!(
+            play_end_idx < rec_rec_idx,
+            "Play::End must precede Record::Recording (activation order): {:?}",
+            observed
+        );
 
         // Crucially: no timeout finish event should appear before the
         // Recording event. (The regression was maxduration firing during
         // the play phase, which would emit Record::Finished first.)
-        let early_finish = observed[..rec_rec_idx].iter().any(|e|
-            matches!(e, Event::Record { state: RecordState::Finished, .. })
-        );
-        assert!(!early_finish,
+        let early_finish = observed[..rec_rec_idx].iter().any(|e| {
+            matches!(
+                e,
+                Event::Record {
+                    state: RecordState::Finished,
+                    ..
+                }
+            )
+        });
+        assert!(
+            !early_finish,
             "no Record::Finished should fire before Record::Recording: {:?}",
-            observed);
+            observed
+        );
 
         handle.close("done").await;
         let _ = std::fs::remove_file(&rec_path);

--- a/rust/src/channel/audio_reader.rs
+++ b/rust/src/channel/audio_reader.rs
@@ -100,23 +100,36 @@ pub struct AudioReader {
 
 impl AudioReader {
     pub fn new(id: u64, cfg: ReaderConfig, sender: mpsc::Sender<Vec<u8>>) -> Self {
-        Self { id, cfg, sender, drops: 0 }
+        Self {
+            id,
+            cfg,
+            sender,
+            drops: 0,
+        }
     }
 
-    pub fn id(&self) -> u64 { self.id }
+    pub fn id(&self) -> u64 {
+        self.id
+    }
     /// Surfaced for diagnostics / future dynamic reconfiguration
     /// (e.g. if a reader's consumer wants to re-query its format
     /// after the fact). Not called from the hot path today.
     #[allow(dead_code)]
-    pub fn config(&self) -> &ReaderConfig { &self.cfg }
+    pub fn config(&self) -> &ReaderConfig {
+        &self.cfg
+    }
     /// Exposes the per-reader drops counter to an eventual `stats()`
     /// summary. Not called yet — the counter is bumped internally.
     #[allow(dead_code)]
-    pub fn drops(&self) -> u64 { self.drops }
+    pub fn drops(&self) -> u64 {
+        self.drops
+    }
 
     /// True once the JS side has dropped its end (forwarder task exited).
     /// Lets the tick garbage-collect finished readers.
-    pub fn is_closed(&self) -> bool { self.sender.is_closed() }
+    pub fn is_closed(&self) -> bool {
+        self.sender.is_closed()
+    }
 
     /// Feed one 20 ms frame. Called from the recorder's feed point in the
     /// tick (same cache state, same timing). Samples are narrowband 8 kHz
@@ -147,12 +160,16 @@ impl AudioReader {
         out_samples_8k: Option<&[i16]>,
         out_samples_16k: Option<&[i16]>,
     ) -> bool {
-        let Some(bytes) = self.build_frame(codecx, in_samples_8k, out_samples_8k, out_samples_16k) else {
+        let Some(bytes) = self.build_frame(codecx, in_samples_8k, out_samples_8k, out_samples_16k)
+        else {
             return false;
         };
         match self.sender.try_send(bytes) {
             Ok(()) => true,
-            Err(_) => { self.drops = self.drops.saturating_add(1); false }
+            Err(_) => {
+                self.drops = self.drops.saturating_add(1);
+                false
+            }
         }
     }
 
@@ -164,7 +181,9 @@ impl AudioReader {
         out_samples_16k: Option<&[i16]>,
     ) -> Option<Vec<u8>> {
         match self.cfg.format {
-            ReaderFormat::L16 => self.build_l16(codecx, in_samples_8k, out_samples_8k, out_samples_16k),
+            ReaderFormat::L16 => {
+                self.build_l16(codecx, in_samples_8k, out_samples_8k, out_samples_16k)
+            }
             ReaderFormat::Pcma => codecx.require_wire_as(8).map(|b| b.to_vec()),
             ReaderFormat::Pcmu => codecx.require_wire_as(0).map(|b| b.to_vec()),
             ReaderFormat::G722 => codecx.require_wire_as(9).map(|b| b.to_vec()),
@@ -182,29 +201,32 @@ impl AudioReader {
         out_samples_16k: Option<&[i16]>,
     ) -> Option<Vec<u8>> {
         // Resolve the two sides at the requested sample rate.
-        let (in_samples, out_samples): (Option<Vec<i16>>, Option<Vec<i16>>) = match self.cfg.samplerate {
-            16000 => {
-                // Inbound wideband is cached on codecx (decoded from G.722, or
-                // upsampled from narrowband). The outbound side has no codecx
-                // here, so its wideband must be supplied by the caller — the
-                // mixer passes the peer's wideband for a bridged call. When it
-                // isn't supplied (e.g. a non-bridged channel whose out is an
-                // 8 kHz player) the out side is silent at 16k.
-                let wb_in = codecx.require_wideband_16k().map(|s| s.to_vec());
-                let wb_out = out_samples_16k.map(|s| s.to_vec());
-                (wb_in, wb_out)
-            }
-            _ => (
-                in_samples_8k.map(|s| s.to_vec()),
-                out_samples_8k.map(|s| s.to_vec()),
-            ),
-        };
+        let (in_samples, out_samples): (Option<Vec<i16>>, Option<Vec<i16>>) =
+            match self.cfg.samplerate {
+                16000 => {
+                    // Inbound wideband is cached on codecx (decoded from G.722, or
+                    // upsampled from narrowband). The outbound side has no codecx
+                    // here, so its wideband must be supplied by the caller — the
+                    // mixer passes the peer's wideband for a bridged call. When it
+                    // isn't supplied (e.g. a non-bridged channel whose out is an
+                    // 8 kHz player) the out side is silent at 16k.
+                    let wb_in = codecx.require_wideband_16k().map(|s| s.to_vec());
+                    let wb_out = out_samples_16k.map(|s| s.to_vec());
+                    (wb_in, wb_out)
+                }
+                _ => (
+                    in_samples_8k.map(|s| s.to_vec()),
+                    out_samples_8k.map(|s| s.to_vec()),
+                ),
+            };
 
         let in_ref: &[i16] = in_samples.as_deref().unwrap_or(&[]);
         let out_ref: &[i16] = out_samples.as_deref().unwrap_or(&[]);
 
         // Nothing to emit (neither side provided samples at this rate).
-        if in_ref.is_empty() && out_ref.is_empty() { return None; }
+        if in_ref.is_empty() && out_ref.is_empty() {
+            return None;
+        }
 
         let n_out = in_ref.len().max(out_ref.len());
         let ch = self.cfg.num_channels as usize;
@@ -213,10 +235,14 @@ impl AudioReader {
         match (self.cfg.direction, ch) {
             (ReaderDirection::In, 1) => push_mono(&mut bytes, in_ref, n_out),
             (ReaderDirection::Out, 1) => push_mono(&mut bytes, out_ref, n_out),
-            (ReaderDirection::Both, 2) => push_stereo_interleaved(&mut bytes, in_ref, out_ref, n_out),
+            (ReaderDirection::Both, 2) => {
+                push_stereo_interleaved(&mut bytes, in_ref, out_ref, n_out)
+            }
             // Mono direction on a stereo reader — duplicate across L/R.
             (ReaderDirection::In, 2) => push_stereo_interleaved(&mut bytes, in_ref, in_ref, n_out),
-            (ReaderDirection::Out, 2) => push_stereo_interleaved(&mut bytes, out_ref, out_ref, n_out),
+            (ReaderDirection::Out, 2) => {
+                push_stereo_interleaved(&mut bytes, out_ref, out_ref, n_out)
+            }
             // direction=Both on a mono reader — sum and return, matches recorder semantics.
             (ReaderDirection::Both, 1) => {
                 for i in 0..n_out {
@@ -286,7 +312,11 @@ mod tests {
 
     fn reader(direction: ReaderDirection, samplerate: u32) -> AudioReader {
         let (tx, _rx) = make_channel();
-        let cfg = ReaderConfig { direction, samplerate, ..Default::default() };
+        let cfg = ReaderConfig {
+            direction,
+            samplerate,
+            ..Default::default()
+        };
         AudioReader::new(1, cfg, tx)
     }
 
@@ -296,16 +326,16 @@ mod tests {
     fn out_reader_16k_uses_supplied_wideband() {
         let r = reader(ReaderDirection::Out, 16000);
         let mut cx = CodecBundle::new();
-        let out_wb: Vec<i16> = vec![ 1234; 320 ]; // 20 ms @ 16 kHz mono
-        let in_8k = vec![ 0i16; 160 ];
-        let out_8k = vec![ 0i16; 160 ];
+        let out_wb: Vec<i16> = vec![1234; 320]; // 20 ms @ 16 kHz mono
+        let in_8k = vec![0i16; 160];
+        let out_8k = vec![0i16; 160];
 
         let bytes = r
             .build_frame(&mut cx, Some(&in_8k), Some(&out_8k), Some(&out_wb))
             .expect("frame produced");
 
         assert_eq!(bytes.len(), 320 * 2, "16k mono 20ms = 640 bytes");
-        assert_eq!(i16::from_le_bytes([ bytes[0], bytes[1] ]), 1234);
+        assert_eq!(i16::from_le_bytes([bytes[0], bytes[1]]), 1234);
     }
 
     // The 8 kHz path is unchanged: the out side uses the 8 kHz samples directly
@@ -314,14 +344,14 @@ mod tests {
     fn out_reader_8k_uses_narrowband() {
         let r = reader(ReaderDirection::Out, 8000);
         let mut cx = CodecBundle::new();
-        let in_8k = vec![ 0i16; 160 ];
-        let out_8k = vec![ 321i16; 160 ];
+        let in_8k = vec![0i16; 160];
+        let out_8k = vec![321i16; 160];
 
         let bytes = r
             .build_frame(&mut cx, Some(&in_8k), Some(&out_8k), None)
             .expect("frame produced");
 
         assert_eq!(bytes.len(), 160 * 2, "8k mono 20ms = 320 bytes");
-        assert_eq!(i16::from_le_bytes([ bytes[0], bytes[1] ]), 321);
+        assert_eq!(i16::from_le_bytes([bytes[0], bytes[1]]), 321);
     }
 }

--- a/rust/src/channel/audio_writer.rs
+++ b/rust/src/channel/audio_writer.rs
@@ -81,14 +81,27 @@ pub struct AudioWriter {
 
 impl AudioWriter {
     pub fn new(id: u64, cfg: WriterConfig, receiver: mpsc::Receiver<Vec<u8>>) -> Self {
-        Self { id, cfg, receiver, buffered: Vec::with_capacity(FRAME_SAMPLES * 2), ended: false, drops: 0 }
+        Self {
+            id,
+            cfg,
+            receiver,
+            buffered: Vec::with_capacity(FRAME_SAMPLES * 2),
+            ended: false,
+            drops: 0,
+        }
     }
 
-    pub fn id(&self) -> u64 { self.id }
+    pub fn id(&self) -> u64 {
+        self.id
+    }
     #[allow(dead_code)]
-    pub fn config(&self) -> &WriterConfig { &self.cfg }
+    pub fn config(&self) -> &WriterConfig {
+        &self.cfg
+    }
     #[allow(dead_code)]
-    pub fn drops(&self) -> u64 { self.drops }
+    pub fn drops(&self) -> u64 {
+        self.drops
+    }
 
     /// True when the JS side has finished AND we've flushed every
     /// sample it gave us. Used by the tick orchestrator to pull the
@@ -165,7 +178,9 @@ mod tests {
         let mut w = AudioWriter::new(1, WriterConfig::default(), rx);
         // 320 bytes = 160 i16 samples = 20 ms @ 8 kHz.
         let mut bytes = Vec::with_capacity(320);
-        for i in 0..160i16 { bytes.extend_from_slice(&i.to_le_bytes()); }
+        for i in 0..160i16 {
+            bytes.extend_from_slice(&i.to_le_bytes());
+        }
         tx.try_send(bytes).unwrap();
         let frame = w.next_frame_8k().unwrap();
         assert_eq!(frame.len(), 160);
@@ -195,11 +210,15 @@ mod tests {
         let mut w = AudioWriter::new(1, WriterConfig::default(), rx);
         // 50 samples then drop the sender (simulates JS .end()).
         let mut bytes = Vec::with_capacity(100);
-        for i in 0..50i16 { bytes.extend_from_slice(&i.to_le_bytes()); }
+        for i in 0..50i16 {
+            bytes.extend_from_slice(&i.to_le_bytes());
+        }
         tx.try_send(bytes).unwrap();
         drop(tx);
 
-        let frame = w.next_frame_8k().expect("partial frame padded with silence");
+        let frame = w
+            .next_frame_8k()
+            .expect("partial frame padded with silence");
         assert_eq!(frame.len(), 160);
         assert_eq!(frame[0], 0);
         assert_eq!(frame[49], 49);

--- a/rust/src/channel/commands.rs
+++ b/rust/src/channel/commands.rs
@@ -32,7 +32,10 @@ pub struct RemoteDtls {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
-pub enum DtlsSetup { Active, Passive }
+pub enum DtlsSetup {
+    Active,
+    Passive,
+}
 
 /// The play config carried on `Command::Play`. Alias for the parsed spec in
 /// `channel/player.rs` — commands used to carry a raw JSON string, but the
@@ -59,7 +62,12 @@ pub struct Direction {
 }
 
 impl Default for Direction {
-    fn default() -> Self { Self { send: true, recv: true } }
+    fn default() -> Self {
+        Self {
+            send: true,
+            recv: true,
+        }
+    }
 }
 
 // Ack types —
@@ -71,16 +79,33 @@ pub type Ack<T = ()> = oneshot::Sender<T>;
 pub type ChannelId = u64;
 
 pub enum Command {
-    Remote { cfg: RemoteConfig, ack: Ack },
-    Play { cfg: SoundSoup, ack: Ack },
-    Record { cfg: RecordConfig, ack: Ack },
+    Remote {
+        cfg: RemoteConfig,
+        ack: Ack,
+    },
+    Play {
+        cfg: SoundSoup,
+        ack: Ack,
+    },
+    Record {
+        cfg: RecordConfig,
+        ack: Ack,
+    },
     /// `channel.record({ finish: true, file: "..." })` — finalize the named
     /// recorder (multiple can coexist, keyed by file path).
-    RecordFinish { file: std::path::PathBuf },
+    RecordFinish {
+        file: std::path::PathBuf,
+    },
     /// `channel.record({ pause: true, file: "..." })` — pause/resume toggle.
     /// `resume=true` flips from Paused to Active; `resume=false` pauses.
-    RecordSetPaused { file: std::path::PathBuf, paused: bool },
-    PlayRecord { cfg: PlayRecordConfig, ack: Ack },
+    RecordSetPaused {
+        file: std::path::PathBuf,
+        paused: bool,
+    },
+    PlayRecord {
+        cfg: PlayRecordConfig,
+        ack: Ack,
+    },
     /// `channel.createReadStream({...})` — register a new audio reader.
     /// The id is generated facade-side (via `audio_reader::next_reader_id`)
     /// and passed in so JS can refer to this reader when it needs to
@@ -93,7 +118,9 @@ pub enum Command {
     },
     /// `readable.destroy()` from JS. Removes the reader with the given
     /// id — dropping it closes the mpsc and ends the forwarder task.
-    DestroyReadStream { id: u64 },
+    DestroyReadStream {
+        id: u64,
+    },
     /// `channel.createWriteStream({...})` — register a writer. Id is
     /// generated facade-side so JS can reference this specific writer
     /// for later byte pushes / end / destroy. The Receiver is
@@ -107,18 +134,31 @@ pub enum Command {
     },
     /// `writable.destroy()` from JS. Removes the writer immediately
     /// — any buffered samples are discarded.
-    DestroyWriteStream { id: u64 },
-    Dtmf { digits: String },
-    Echo { enabled: bool },
+    DestroyWriteStream {
+        id: u64,
+    },
+    Dtmf {
+        digits: String,
+    },
+    Echo {
+        enabled: bool,
+    },
     Direction(Direction),
     /// Migrate this channel's state + subs into a mix group actor. The actor
     /// transitions from Local to Mixed mode; subsequent commands are
     /// forwarded into the mixer. `ack` fires once the migration completes.
-    EnterMix { mix: super::mixer::MixHandle, ack: Ack },
+    EnterMix {
+        mix: super::mixer::MixHandle,
+        ack: Ack,
+    },
     /// Migrate state + subs back out of the mix group. The actor returns to
     /// Local mode and resumes its own ticker. Used for `channel.unmix()`.
-    LeaveMix { ack: Ack },
-    Close { reason: String },
+    LeaveMix {
+        ack: Ack,
+    },
+    Close {
+        reason: String,
+    },
 }
 
 // The public handle JS holds (indirectly, via a wrapper in channel/mod.rs).
@@ -132,11 +172,21 @@ pub struct Handle {
 #[allow(dead_code)]
 impl Handle {
     pub async fn close(&self, reason: impl Into<String>) {
-        let _ = self.cmd.send(Command::Close { reason: reason.into() }).await;
+        let _ = self
+            .cmd
+            .send(Command::Close {
+                reason: reason.into(),
+            })
+            .await;
     }
 
     pub async fn dtmf(&self, digits: impl Into<String>) {
-        let _ = self.cmd.send(Command::Dtmf { digits: digits.into() }).await;
+        let _ = self
+            .cmd
+            .send(Command::Dtmf {
+                digits: digits.into(),
+            })
+            .await;
     }
 
     pub async fn echo(&self, on: bool) {
@@ -149,25 +199,37 @@ impl Handle {
 
     pub async fn remote(&self, cfg: RemoteConfig) -> Result<(), ()> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(Command::Remote { cfg, ack: tx }).await.map_err(|_| ())?;
+        self.cmd
+            .send(Command::Remote { cfg, ack: tx })
+            .await
+            .map_err(|_| ())?;
         rx.await.map_err(|_| ())
     }
 
     pub async fn play(&self, cfg: SoundSoup) -> Result<(), ()> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(Command::Play { cfg, ack: tx }).await.map_err(|_| ())?;
+        self.cmd
+            .send(Command::Play { cfg, ack: tx })
+            .await
+            .map_err(|_| ())?;
         rx.await.map_err(|_| ())
     }
 
     pub async fn record(&self, cfg: RecordConfig) -> Result<(), ()> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(Command::Record { cfg, ack: tx }).await.map_err(|_| ())?;
+        self.cmd
+            .send(Command::Record { cfg, ack: tx })
+            .await
+            .map_err(|_| ())?;
         rx.await.map_err(|_| ())
     }
 
     pub async fn play_record(&self, cfg: PlayRecordConfig) -> Result<(), ()> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(Command::PlayRecord { cfg, ack: tx }).await.map_err(|_| ())?;
+        self.cmd
+            .send(Command::PlayRecord { cfg, ack: tx })
+            .await
+            .map_err(|_| ())?;
         rx.await.map_err(|_| ())
     }
 }

--- a/rust/src/channel/dtls_session.rs
+++ b/rust/src/channel/dtls_session.rs
@@ -95,12 +95,16 @@ impl webrtc_util::Conn for DtlsTransport {
 
     async fn send(&self, buf: &[u8]) -> webrtc_util::Result<usize> {
         let remote = (*self.remote_addr.lock()).unwrap_or(self.local_addr);
-        self.sock.send_to(buf, remote).await
+        self.sock
+            .send_to(buf, remote)
+            .await
             .map_err(|e| webrtc_util::Error::Other(e.to_string()))
     }
 
     async fn send_to(&self, buf: &[u8], target: SocketAddr) -> webrtc_util::Result<usize> {
-        self.sock.send_to(buf, target).await
+        self.sock
+            .send_to(buf, target)
+            .await
             .map_err(|e| webrtc_util::Error::Other(e.to_string()))
     }
 
@@ -185,7 +189,8 @@ pub fn spawn_handshake(
         let outcome = tokio::time::timeout(
             HANDSHAKE_TIMEOUT,
             DTLSConn::new(transport, config, is_client, None),
-        ).await;
+        )
+        .await;
 
         let result = match outcome {
             Ok(Ok(conn)) => {
@@ -210,7 +215,10 @@ pub fn spawn_handshake(
         let _ = result_tx.send(result);
     });
 
-    HandshakeHandle { result_rx, abort: join.abort_handle() }
+    HandshakeHandle {
+        result_rx,
+        abort: join.abort_handle(),
+    }
 }
 
 /// Split exported keying material into client/server key + salt pairs.
@@ -224,9 +232,12 @@ pub fn split_keying_material(
     let key_len = profile.key_len();
     let salt_len = profile.salt_len();
     let mut off = 0;
-    let client_write_key = km[off..off + key_len].to_vec(); off += key_len;
-    let server_write_key = km[off..off + key_len].to_vec(); off += key_len;
-    let client_write_salt = km[off..off + salt_len].to_vec(); off += salt_len;
+    let client_write_key = km[off..off + key_len].to_vec();
+    off += key_len;
+    let server_write_key = km[off..off + key_len].to_vec();
+    off += key_len;
+    let client_write_salt = km[off..off + salt_len].to_vec();
+    off += salt_len;
     let server_write_salt = km[off..off + salt_len].to_vec();
     let _ = off;
     SrtpKeyingMaterial {
@@ -292,11 +303,19 @@ mod tests {
         let server_remote = Arc::new(PLMutex::new(Some(client_addr)));
         let client_remote = Arc::new(PLMutex::new(Some(server_addr)));
         let server_h = spawn_handshake(
-            DtlsSetup::Passive, server_addr, server_sock, server_dtls_rx, server_cert,
+            DtlsSetup::Passive,
+            server_addr,
+            server_sock,
+            server_dtls_rx,
+            server_cert,
             server_remote,
         );
         let client_h = spawn_handshake(
-            DtlsSetup::Active, client_addr, client_sock, client_dtls_rx, client_cert,
+            DtlsSetup::Active,
+            client_addr,
+            client_sock,
+            client_dtls_rx,
+            client_cert,
             client_remote,
         );
 
@@ -320,10 +339,14 @@ mod tests {
         assert!(client_km.is_client);
 
         let server_keys = split_keying_material(
-            &server_km.keying_material, server_km.profile, server_km.is_client,
+            &server_km.keying_material,
+            server_km.profile,
+            server_km.is_client,
         );
         let client_keys = split_keying_material(
-            &client_km.keying_material, client_km.profile, client_km.is_client,
+            &client_km.keying_material,
+            client_km.profile,
+            client_km.is_client,
         );
         assert_eq!(server_keys.client_write_key, client_keys.client_write_key);
         assert_eq!(server_keys.server_write_key, client_keys.server_write_key);
@@ -332,20 +355,32 @@ mod tests {
         let mut encrypt_ctx = webrtc_srtp::context::Context::new(
             &client_keys.client_write_key,
             &client_keys.client_write_salt,
-            client_keys.profile, None, None,
-        ).expect("srtp encrypt ctx");
+            client_keys.profile,
+            None,
+            None,
+        )
+        .expect("srtp encrypt ctx");
 
         let mut decrypt_ctx = webrtc_srtp::context::Context::new(
             &server_keys.client_write_key,
             &server_keys.client_write_salt,
-            server_keys.profile, None, None,
-        ).expect("srtp decrypt ctx");
+            server_keys.profile,
+            None,
+            None,
+        )
+        .expect("srtp decrypt ctx");
 
-        let mut rtp_pkt = vec![0x80, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xA0, 0x00, 0x00, 0x00, 0x01];
+        let mut rtp_pkt = vec![
+            0x80, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xA0, 0x00, 0x00, 0x00, 0x01,
+        ];
         rtp_pkt.extend_from_slice(&[0x55u8; 160]);
 
         let encrypted = encrypt_ctx.encrypt_rtp(&rtp_pkt).expect("encrypt");
-        assert_ne!(&encrypted[12..], &rtp_pkt[12..], "payload should be encrypted");
+        assert_ne!(
+            &encrypted[12..],
+            &rtp_pkt[12..],
+            "payload should be encrypted"
+        );
 
         let decrypted = decrypt_ctx.decrypt_rtp(&encrypted).expect("decrypt");
         assert_eq!(&decrypted[..], &rtp_pkt[..], "round-trip should match");

--- a/rust/src/channel/dtmf.rs
+++ b/rust/src/channel/dtmf.rs
@@ -26,10 +26,10 @@ pub const END_REPEATS: u8 = 3;
 // quieter than the C++ sender and was flagged during interop review.
 pub const DEFAULT_VOLUME: u8 = 13;
 pub const EVENT_DURATION_UNIT: u16 = 160; // one G.711 packet worth
-// Minimum gap between consecutive DTMF bursts, in tick units (20 ms). The
-// C++ sender enforces `snout - lastdtmfsn >= 10` before starting the next
-// burst, i.e. 200 ms. Some endpoints coalesce digits sent faster than
-// this into a single event or miss the second press entirely.
+                                          // Minimum gap between consecutive DTMF bursts, in tick units (20 ms). The
+                                          // C++ sender enforces `snout - lastdtmfsn >= 10` before starting the next
+                                          // burst, i.e. 200 ms. Some endpoints coalesce digits sent faster than
+                                          // this into a single event or miss the second press entirely.
 pub const INTER_DIGIT_GAP_TICKS: u8 = 10;
 
 /// Maps a DTMF character to its RFC 2833 event code. Accepted chars match C++
@@ -82,12 +82,19 @@ pub struct DecodedEvent {
 }
 
 pub fn decode_event(payload: &[u8]) -> Option<DecodedEvent> {
-    if payload.len() < 4 { return None; }
+    if payload.len() < 4 {
+        return None;
+    }
     let event = payload[0];
     let end = payload[1] & 0x80 != 0;
     let volume = payload[1] & 0x3F;
     let duration = u16::from_be_bytes([payload[2], payload[3]]);
-    Some(DecodedEvent { event, end, volume, duration })
+    Some(DecodedEvent {
+        event,
+        end,
+        volume,
+        duration,
+    })
 }
 
 /// One packet ready to go on the wire. Callers copy these fields onto the
@@ -135,10 +142,14 @@ pub struct DtmfSender {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct DtmfBurst { event: u8 }
+struct DtmfBurst {
+    event: u8,
+}
 
 impl Default for DtmfSender {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DtmfSender {
@@ -183,8 +194,12 @@ impl DtmfSender {
             if self.idle_ticks_since_burst < INTER_DIGIT_GAP_TICKS {
                 self.idle_ticks_since_burst += 1;
             }
-            if self.queue.is_empty() { return None; }
-            if self.idle_ticks_since_burst < INTER_DIGIT_GAP_TICKS { return None; }
+            if self.queue.is_empty() {
+                return None;
+            }
+            if self.idle_ticks_since_burst < INTER_DIGIT_GAP_TICKS {
+                return None;
+            }
 
             let burst = self.queue.pop_front()?;
             self.current_event = Some(burst.event);
@@ -204,7 +219,12 @@ impl DtmfSender {
             self.ticks_remaining -= 1;
             let payload = encode_event(event, false, DEFAULT_VOLUME, self.duration_ticks);
             self.duration_ticks = self.duration_ticks.saturating_add(EVENT_DURATION_UNIT);
-            return Some(NextDtmfPacket { event, payload, marker, timestamp: ts });
+            return Some(NextDtmfPacket {
+                event,
+                payload,
+                marker,
+                timestamp: ts,
+            });
         }
 
         if self.end_remaining > 0 {
@@ -215,7 +235,12 @@ impl DtmfSender {
                 self.burst_ts = None;
                 self.idle_ticks_since_burst = 0;
             }
-            return Some(NextDtmfPacket { event, payload, marker: false, timestamp: ts });
+            return Some(NextDtmfPacket {
+                event,
+                payload,
+                marker: false,
+                timestamp: ts,
+            });
         }
 
         // Unreachable: the `current_event.is_none()` guard above covers
@@ -253,12 +278,18 @@ pub struct DtmfReceiver {
 const NEW_BURST_TS_DELTA: u32 = 3200;
 
 impl Default for DtmfReceiver {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DtmfReceiver {
     pub fn new() -> Self {
-        Self { last_sn: None, last_event: None, last_event_ts: None }
+        Self {
+            last_sn: None,
+            last_event: None,
+            last_event_ts: None,
+        }
     }
 
     /// Feed an RFC 2833 payload with its RTP sequence number and
@@ -275,7 +306,9 @@ impl DtmfReceiver {
             Some(last) => sn.wrapping_sub(last) < 0x8000 && sn != last,
             None => true,
         };
-        if !advanced { return None; }
+        if !advanced {
+            return None;
+        }
         self.last_sn = Some(sn);
 
         if ev.end {
@@ -297,7 +330,9 @@ impl DtmfReceiver {
             None => false,
         };
         let same_burst = same_event && !big_ts_gap;
-        if same_burst { return None; }
+        if same_burst {
+            return None;
+        }
 
         self.last_event = Some(ev.event);
         self.last_event_ts = Some(ts);
@@ -334,7 +369,11 @@ mod tests {
         let mut body = 0;
         let mut ends = 0;
         while let Some(pkt) = s.next_event(0) {
-            if pkt.payload[1] & 0x80 != 0 { ends += 1; } else { body += 1; }
+            if pkt.payload[1] & 0x80 != 0 {
+                ends += 1;
+            } else {
+                body += 1;
+            }
         }
         assert_eq!(body, EVENT_REPEATS as usize);
         assert_eq!(ends, END_REPEATS as usize);
@@ -407,8 +446,11 @@ mod tests {
             ts_seen.push(s.next_event(caller_ts).unwrap().timestamp);
         }
         // Every packet in the burst must carry the burst-start value.
-        assert!(ts_seen.iter().all(|&ts| ts == 1_000),
-                "burst TS drifted: {:?}", ts_seen);
+        assert!(
+            ts_seen.iter().all(|&ts| ts == 1_000),
+            "burst TS drifted: {:?}",
+            ts_seen
+        );
     }
 
     #[test]
@@ -418,7 +460,10 @@ mod tests {
         // from "the prior burst that never happened".
         let mut s = DtmfSender::new();
         s.enqueue("0");
-        assert!(s.next_event(0).is_some(), "first digit must fire immediately");
+        assert!(
+            s.next_event(0).is_some(),
+            "first digit must fire immediately"
+        );
     }
 
     #[test]
@@ -451,39 +496,181 @@ mod tests {
         // clearing, not the timestamp fallback.
         let mut r = DtmfReceiver::new();
         let bursts: &[(u32, u8, &[(u16, bool)])] = &[
-            (36160,  9, &[(226,false),(228,false),(230,false),(232,false),
-                          (234,false),(236,false),(238,false),
-                          (239,true),(241,true),(242,true)]),
-            (113280, 1, &[(718,false),(720,false),(722,false),(724,false),
-                          (726,false),(728,false),(730,false),
-                          (731,true),(733,true),(734,true)]),
-            (116640, 9, &[(749,false),(751,false),(753,false),(755,false),
-                          (757,false),(759,false),(761,false),
-                          (762,true),(764,true),(765,true)]),
-            (120000, 9, &[(780,false),(782,false),(784,false),(786,false),
-                          (788,false),(790,false),(792,false),
-                          (793,true),(795,true),(796,true)]),
-            (123200, 3, &[(810,false),(812,false),(814,false),(816,false),
-                          (818,false),(820,false),(822,false),
-                          (823,true),(825,true),(826,true)]),
-            (179840, 3, &[(1174,false),(1176,false),(1178,false),(1180,false),
-                          (1182,false),(1184,false),(1186,false),
-                          (1187,true),(1189,true),(1190,true)]),
-            (232640, 1, &[(1514,false),(1516,false),(1518,false),(1520,false),
-                          (1522,false),(1524,false),(1526,false),
-                          (1527,true),(1529,true),(1530,true)]),
-            (235200, 1, &[(1540,false),(1542,false),(1544,false),(1546,false),
-                          (1548,false),(1550,false),
-                          (1551,true),(1553,true),(1554,true)]),
-            (261440, 1, &[(1713,false),(1715,false),(1717,false),(1719,false),
-                          (1721,false),(1723,false),(1725,false),
-                          (1726,true),(1728,true),(1729,true)]),
-            (324800, 1, &[(2119,false),(2121,false),(2123,false),(2125,false),
-                          (2127,false),(2129,false),(2131,false),
-                          (2132,true),(2134,true),(2135,true)]),
-            (328480, 2, &[(2152,false),(2154,false),(2156,false),(2158,false),
-                          (2160,false),(2162,false),(2164,false),
-                          (2165,true),(2167,true),(2168,true)]),
+            (
+                36160,
+                9,
+                &[
+                    (226, false),
+                    (228, false),
+                    (230, false),
+                    (232, false),
+                    (234, false),
+                    (236, false),
+                    (238, false),
+                    (239, true),
+                    (241, true),
+                    (242, true),
+                ],
+            ),
+            (
+                113280,
+                1,
+                &[
+                    (718, false),
+                    (720, false),
+                    (722, false),
+                    (724, false),
+                    (726, false),
+                    (728, false),
+                    (730, false),
+                    (731, true),
+                    (733, true),
+                    (734, true),
+                ],
+            ),
+            (
+                116640,
+                9,
+                &[
+                    (749, false),
+                    (751, false),
+                    (753, false),
+                    (755, false),
+                    (757, false),
+                    (759, false),
+                    (761, false),
+                    (762, true),
+                    (764, true),
+                    (765, true),
+                ],
+            ),
+            (
+                120000,
+                9,
+                &[
+                    (780, false),
+                    (782, false),
+                    (784, false),
+                    (786, false),
+                    (788, false),
+                    (790, false),
+                    (792, false),
+                    (793, true),
+                    (795, true),
+                    (796, true),
+                ],
+            ),
+            (
+                123200,
+                3,
+                &[
+                    (810, false),
+                    (812, false),
+                    (814, false),
+                    (816, false),
+                    (818, false),
+                    (820, false),
+                    (822, false),
+                    (823, true),
+                    (825, true),
+                    (826, true),
+                ],
+            ),
+            (
+                179840,
+                3,
+                &[
+                    (1174, false),
+                    (1176, false),
+                    (1178, false),
+                    (1180, false),
+                    (1182, false),
+                    (1184, false),
+                    (1186, false),
+                    (1187, true),
+                    (1189, true),
+                    (1190, true),
+                ],
+            ),
+            (
+                232640,
+                1,
+                &[
+                    (1514, false),
+                    (1516, false),
+                    (1518, false),
+                    (1520, false),
+                    (1522, false),
+                    (1524, false),
+                    (1526, false),
+                    (1527, true),
+                    (1529, true),
+                    (1530, true),
+                ],
+            ),
+            (
+                235200,
+                1,
+                &[
+                    (1540, false),
+                    (1542, false),
+                    (1544, false),
+                    (1546, false),
+                    (1548, false),
+                    (1550, false),
+                    (1551, true),
+                    (1553, true),
+                    (1554, true),
+                ],
+            ),
+            (
+                261440,
+                1,
+                &[
+                    (1713, false),
+                    (1715, false),
+                    (1717, false),
+                    (1719, false),
+                    (1721, false),
+                    (1723, false),
+                    (1725, false),
+                    (1726, true),
+                    (1728, true),
+                    (1729, true),
+                ],
+            ),
+            (
+                324800,
+                1,
+                &[
+                    (2119, false),
+                    (2121, false),
+                    (2123, false),
+                    (2125, false),
+                    (2127, false),
+                    (2129, false),
+                    (2131, false),
+                    (2132, true),
+                    (2134, true),
+                    (2135, true),
+                ],
+            ),
+            (
+                328480,
+                2,
+                &[
+                    (2152, false),
+                    (2154, false),
+                    (2156, false),
+                    (2158, false),
+                    (2160, false),
+                    (2162, false),
+                    (2164, false),
+                    (2165, true),
+                    (2167, true),
+                    (2168, true),
+                ],
+            ),
         ];
         let mut got: Vec<char> = Vec::new();
         for (ts, event, packets) in bursts {
@@ -494,8 +681,12 @@ mod tests {
                 }
             }
         }
-        assert_eq!(got, vec!['9','1','9','9','3','3','1','1','1','1','2'],
-                   "expected full IVR sequence, got {:?}", got);
+        assert_eq!(
+            got,
+            vec!['9', '1', '9', '9', '3', '3', '1', '1', '1', '1', '2'],
+            "expected full IVR sequence, got {:?}",
+            got
+        );
     }
 
     #[test]

--- a/rust/src/channel/facade.rs
+++ b/rust/src/channel/facade.rs
@@ -90,17 +90,35 @@ struct EventPayload {
 fn event_to_payload(ev: Event) -> EventPayload {
     match ev {
         Event::Close { reason, stats } => EventPayload {
-            action: "close", reason: Some(reason), event: None, state: None,
-            stats: Some(stats), file: None, filesize: None,
+            action: "close",
+            reason: Some(reason),
+            event: None,
+            state: None,
+            stats: Some(stats),
+            file: None,
+            filesize: None,
         },
         Event::Play { state, reason } => EventPayload {
-            action: "play", reason,
-            event: Some(match state { PlayState::Start => "start", PlayState::End => "end" }.into()),
+            action: "play",
+            reason,
+            event: Some(
+                match state {
+                    PlayState::Start => "start",
+                    PlayState::End => "end",
+                }
+                .into(),
+            ),
             state: None,
             stats: None,
-            file: None, filesize: None,
+            file: None,
+            filesize: None,
         },
-        Event::Record { state, reason, file, filesize } => {
+        Event::Record {
+            state,
+            reason,
+            file,
+            filesize,
+        } => {
             // C++ surfaces both recording and finish transitions with a
             // compound event name — `recording.abovepower` when a
             // power-gated recorder starts writing, `finished.belowpower` /
@@ -115,18 +133,33 @@ fn event_to_payload(ev: Event) -> EventPayload {
                 None => prefix.to_string(),
             };
             EventPayload {
-                action: "record", reason, event: Some(event), state: None,
-                stats: None, file, filesize,
+                action: "record",
+                reason,
+                event: Some(event),
+                state: None,
+                stats: None,
+                file,
+                filesize,
             }
         }
         Event::TelephoneEvent { digit } => EventPayload {
-            action: "telephone-event", reason: None, event: Some(digit.to_string()), state: None,
-            stats: None, file: None, filesize: None,
+            action: "telephone-event",
+            reason: None,
+            event: Some(digit.to_string()),
+            state: None,
+            stats: None,
+            file: None,
+            filesize: None,
         },
         Event::Mix { state } => EventPayload {
             // Tests read `d.event` for "start" / "finished", not `d.state`.
-            action: "mix", reason: None, event: Some(state), state: None,
-            stats: None, file: None, filesize: None,
+            action: "mix",
+            reason: None,
+            event: Some(state),
+            state: None,
+            stats: None,
+            file: None,
+            filesize: None,
         },
     }
 }
@@ -136,7 +169,10 @@ struct JsEventSink {
 }
 impl EventSink for JsEventSink {
     fn post(&self, ev: Event) {
-        self.tsfn.call(event_to_payload(ev), ThreadsafeFunctionCallMode::NonBlocking);
+        self.tsfn.call(
+            event_to_payload(ev),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
     }
 }
 
@@ -198,7 +234,8 @@ pub struct ChannelObject {
     /// `end_write_stream` can route to the right one. Guarded by a
     /// `parking_lot::Mutex` so `push` is lock-cheap on the hot path —
     /// we don't want a contended std mutex between every 20 ms frame.
-    write_senders: parking_lot::Mutex<std::collections::HashMap<u64, tokio::sync::mpsc::Sender<Vec<u8>>>>,
+    write_senders:
+        parking_lot::Mutex<std::collections::HashMap<u64, tokio::sync::mpsc::Sender<Vec<u8>>>>,
 }
 
 // The `#[napi]` proc macro on an impl block needs to expand before the
@@ -210,10 +247,14 @@ pub struct ChannelObject {
 #[napi]
 impl ChannelObject {
     #[napi(getter)]
-    pub fn ssrc(&self) -> u32 { self.channel_ssrc }
+    pub fn ssrc(&self) -> u32 {
+        self.channel_ssrc
+    }
 
     #[napi(getter)]
-    pub fn port(&self) -> u32 { self.channel_port as u32 }
+    pub fn port(&self) -> u32 {
+        self.channel_port as u32
+    }
 
     // index.js expects to read chan.local.{port,ssrc} right after openchannel,
     // then assign chan.local.address = ... Defensive JS already handles the
@@ -223,15 +264,22 @@ impl ChannelObject {
     // returns. We only expose the constituent fields; napi-rs class getters
     // would be non-writable and can't be shadowed by the JS wrapper.
     #[napi(getter)]
-    pub fn icepwd(&self) -> String { self.channel_icepwd.clone() }
+    pub fn icepwd(&self) -> String {
+        self.channel_icepwd.clone()
+    }
 
     #[napi(getter)]
-    pub fn dtlsfingerprint(&self) -> String { crate::dtls::fingerprint().to_string() }
+    pub fn dtlsfingerprint(&self) -> String {
+        crate::dtls::fingerprint().to_string()
+    }
 
     #[napi]
     pub fn close(&self, reason: Option<String>) -> bool {
         let r = reason.unwrap_or_else(|| "requested".into());
-        self.handle.cmd.try_send(super::commands::Command::Close { reason: r }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::Close { reason: r })
+            .is_ok()
     }
 
     #[napi]
@@ -252,10 +300,13 @@ impl ChannelObject {
     /// JS calls `channel.direction({ send, recv })` with a single object.
     #[napi]
     pub fn direction(&self, opts: DirectionOpts) -> bool {
-        self.handle.cmd.try_send(super::commands::Command::Direction(Direction {
-            send: opts.send.unwrap_or(true),
-            recv: opts.recv.unwrap_or(true),
-        })).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::Direction(Direction {
+                send: opts.send.unwrap_or(true),
+                recv: opts.recv.unwrap_or(true),
+            }))
+            .is_ok()
     }
 
     /// Reconfigure the remote end for outbound RTP. JS calls
@@ -272,22 +323,31 @@ impl ChannelObject {
         let codec = params.get_named_property::<u32>("codec").ok().unwrap_or(0);
         let icepwd = params.get_named_property::<String>("icepwd").ok();
         let dtls = parse_remote_dtls(&params);
-        let Some(addr_s) = addr else { return false; };
-        let Some(port_n) = port else { return false; };
-        let Ok(ip) = addr_s.parse::<IpAddr>() else { return false; };
+        let Some(addr_s) = addr else {
+            return false;
+        };
+        let Some(port_n) = port else {
+            return false;
+        };
+        let Ok(ip) = addr_s.parse::<IpAddr>() else {
+            return false;
+        };
         let sa = SocketAddr::new(ip, port_n as u16);
         let (ack, _) = tokio::sync::oneshot::channel();
-        self.handle.cmd.try_send(super::commands::Command::Remote {
-            cfg: super::commands::RemoteConfig {
-                addr: sa,
-                payload_type: codec as u8,
-                ilbc_payload_type: None,
-                rfc2833_payload_type: None,
-                dtls,
-                icepwd,
-            },
-            ack,
-        }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::Remote {
+                cfg: super::commands::RemoteConfig {
+                    addr: sa,
+                    payload_type: codec as u8,
+                    ilbc_payload_type: None,
+                    rfc2833_payload_type: None,
+                    dtls,
+                    icepwd,
+                },
+                ack,
+            })
+            .is_ok()
     }
 
     /// Start (or replace) a soundsoup playback on this channel. JS shape
@@ -297,9 +357,14 @@ impl ChannelObject {
     /// commands) when the spec is invalid so tests can assert failure.
     #[napi]
     pub fn play(&self, params: Object) -> bool {
-        let Some(spec) = parse_soundsoup(&params) else { return false; };
+        let Some(spec) = parse_soundsoup(&params) else {
+            return false;
+        };
         let (ack, _) = tokio::sync::oneshot::channel();
-        self.handle.cmd.try_send(super::commands::Command::Play { cfg: spec, ack }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::Play { cfg: spec, ack })
+            .is_ok()
     }
 
     /// Start (or finish / pause) a recording. Shapes:
@@ -310,23 +375,43 @@ impl ChannelObject {
     /// recorders (different `file`s) can coexist on one channel.
     #[napi]
     pub fn record(&self, params: Object) -> bool {
-        let file = params.get_named_property::<String>("file").ok().filter(|s| !s.is_empty());
+        let file = params
+            .get_named_property::<String>("file")
+            .ok()
+            .filter(|s| !s.is_empty());
         if params.get_named_property::<bool>("finish").ok() == Some(true) {
-            let Some(file) = file else { return false; };
-            return self.handle.cmd.try_send(super::commands::Command::RecordFinish {
-                file: std::path::PathBuf::from(file),
-            }).is_ok();
+            let Some(file) = file else {
+                return false;
+            };
+            return self
+                .handle
+                .cmd
+                .try_send(super::commands::Command::RecordFinish {
+                    file: std::path::PathBuf::from(file),
+                })
+                .is_ok();
         }
         if params.get_named_property::<bool>("pause").ok() == Some(true) {
-            let Some(file) = file else { return false; };
-            return self.handle.cmd.try_send(super::commands::Command::RecordSetPaused {
-                file: std::path::PathBuf::from(file),
-                paused: true,
-            }).is_ok();
+            let Some(file) = file else {
+                return false;
+            };
+            return self
+                .handle
+                .cmd
+                .try_send(super::commands::Command::RecordSetPaused {
+                    file: std::path::PathBuf::from(file),
+                    paused: true,
+                })
+                .is_ok();
         }
-        let Some(cfg) = parse_recorder(&params) else { return false; };
+        let Some(cfg) = parse_recorder(&params) else {
+            return false;
+        };
         let (ack, _) = tokio::sync::oneshot::channel();
-        self.handle.cmd.try_send(super::commands::Command::Record { cfg, ack }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::Record { cfg, ack })
+            .is_ok()
     }
 
     /// Register a live audio reader. `callback` is invoked from a dedicated
@@ -348,10 +433,13 @@ impl ChannelObject {
         // if its own queue is full — the forwarder task must never stall
         // the 20 ms tick pipeline upstream.
         let mut tsfn: ThreadsafeFunction<Vec<u8>, ErrorStrategy::Fatal> = callback
-            .create_threadsafe_function(0, |ctx: napi::threadsafe_function::ThreadSafeCallContext<Vec<u8>>| {
-                let buf = ctx.env.create_buffer_with_data(ctx.value)?;
-                Ok(vec![buf.into_raw()])
-            })?;
+            .create_threadsafe_function(
+                0,
+                |ctx: napi::threadsafe_function::ThreadSafeCallContext<Vec<u8>>| {
+                    let buf = ctx.env.create_buffer_with_data(ctx.value)?;
+                    Ok(vec![buf.into_raw()])
+                },
+            )?;
         tsfn.unref(&env)?;
 
         let (sender, mut receiver) = super::audio_reader::make_channel();
@@ -370,11 +458,12 @@ impl ChannelObject {
             tsfn.call(Vec::new(), ThreadsafeFunctionCallMode::NonBlocking);
         });
 
-        if self.handle.cmd.try_send(super::commands::Command::CreateReadStream {
-            id,
-            cfg,
-            sender,
-        }).is_err() {
+        if self
+            .handle
+            .cmd
+            .try_send(super::commands::Command::CreateReadStream { id, cfg, sender })
+            .is_err()
+        {
             return Ok(0);
         }
         // u32 is plenty — id is monotonic and channels are short-lived. Cast
@@ -387,9 +476,10 @@ impl ChannelObject {
     /// the handler is a no-op if the id isn't found.
     #[napi]
     pub fn destroy_read_stream(&self, id: u32) -> bool {
-        self.handle.cmd.try_send(super::commands::Command::DestroyReadStream {
-            id: id as u64,
-        }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::DestroyReadStream { id: id as u64 })
+            .is_ok()
     }
 
     /// Register a live audio writer. JS wraps the returned id in a Node
@@ -404,9 +494,12 @@ impl ChannelObject {
         let cfg = parse_writer_config(&params);
         let (sender, receiver) = super::audio_writer::make_channel();
         let id = super::audio_writer::next_writer_id();
-        if self.handle.cmd.try_send(super::commands::Command::CreateWriteStream {
-            id, cfg, receiver,
-        }).is_err() {
+        if self
+            .handle
+            .cmd
+            .try_send(super::commands::Command::CreateWriteStream { id, cfg, receiver })
+            .is_err()
+        {
             return 0;
         }
         self.write_senders.lock().insert(id, sender);
@@ -424,7 +517,9 @@ impl ChannelObject {
             let map = self.write_senders.lock();
             map.get(&(id as u64)).cloned()
         };
-        let Some(sender) = sender else { return false; };
+        let Some(sender) = sender else {
+            return false;
+        };
         sender.try_send(buf.to_vec()).is_ok()
     }
 
@@ -443,9 +538,10 @@ impl ChannelObject {
     #[napi]
     pub fn destroy_write_stream(&self, id: u32) -> bool {
         let _ = self.write_senders.lock().remove(&(id as u64));
-        self.handle.cmd.try_send(super::commands::Command::DestroyWriteStream {
-            id: id as u64,
-        }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::DestroyWriteStream { id: id as u64 })
+            .is_ok()
     }
 
     /// Play a prompt then record; optionally barge-in on loud inbound audio.
@@ -453,13 +549,26 @@ impl ChannelObject {
     /// bargeinpower, bargeinpoweraveragepackets }`.
     #[napi]
     pub fn playrecord(&self, params: Object) -> bool {
-        let Ok(soup_obj) = params.get_named_property::<Object>("soup") else { return false; };
-        let Some(player) = parse_soundsoup(&soup_obj) else { return false; };
-        let Ok(rec_obj) = params.get_named_property::<Object>("record") else { return false; };
-        let Some(recorder) = parse_recorder(&rec_obj) else { return false; };
-        let interrupt = params.get_named_property::<bool>("interrupt").ok().unwrap_or(false);
+        let Ok(soup_obj) = params.get_named_property::<Object>("soup") else {
+            return false;
+        };
+        let Some(player) = parse_soundsoup(&soup_obj) else {
+            return false;
+        };
+        let Ok(rec_obj) = params.get_named_property::<Object>("record") else {
+            return false;
+        };
+        let Some(recorder) = parse_recorder(&rec_obj) else {
+            return false;
+        };
+        let interrupt = params
+            .get_named_property::<bool>("interrupt")
+            .ok()
+            .unwrap_or(false);
         let bargein_power = params.get_named_property::<i32>("bargeinpower").ok();
-        let bargein_packets = params.get_named_property::<u32>("bargeinpoweraveragepackets").ok();
+        let bargein_packets = params
+            .get_named_property::<u32>("bargeinpoweraveragepackets")
+            .ok();
         let cfg = super::commands::PlayRecordConfig {
             player,
             recorder,
@@ -468,7 +577,10 @@ impl ChannelObject {
             bargein_packets,
         };
         let (ack, _) = tokio::sync::oneshot::channel();
-        self.handle.cmd.try_send(super::commands::Command::PlayRecord { cfg, ack }).is_ok()
+        self.handle
+            .cmd
+            .try_send(super::commands::Command::PlayRecord { cfg, ack })
+            .is_ok()
     }
 
     /// Place both channels in a shared mix group. The channels' state and
@@ -480,7 +592,10 @@ impl ChannelObject {
     pub fn mix(&self, other: &ChannelObject) -> bool {
         // Deadlock-avoidance: always lock in ascending channel-id order.
         let (mut self_guard, mut other_guard) = if self.handle.id < other.handle.id {
-            (self.mix_slot.lock().unwrap(), other.mix_slot.lock().unwrap())
+            (
+                self.mix_slot.lock().unwrap(),
+                other.mix_slot.lock().unwrap(),
+            )
         } else if self.handle.id > other.handle.id {
             let og = other.mix_slot.lock().unwrap();
             let sg = self.mix_slot.lock().unwrap();
@@ -514,15 +629,18 @@ impl ChannelObject {
         *self_slot = Some(mix.clone());
         *other_slot = Some(mix.clone());
         let (ack, _) = tokio::sync::oneshot::channel();
-        let _ = self.handle.cmd.try_send(super::commands::Command::EnterMix {
-            mix: mix.clone(),
-            ack,
-        });
+        let _ = self
+            .handle
+            .cmd
+            .try_send(super::commands::Command::EnterMix {
+                mix: mix.clone(),
+                ack,
+            });
         let (ack, _) = tokio::sync::oneshot::channel();
-        let _ = other.handle.cmd.try_send(super::commands::Command::EnterMix {
-            mix,
-            ack,
-        });
+        let _ = other
+            .handle
+            .cmd
+            .try_send(super::commands::Command::EnterMix { mix, ack });
         true
     }
 
@@ -530,7 +648,10 @@ impl ChannelObject {
     pub fn unmix(&self, _other: Option<&ChannelObject>) -> bool {
         *self.mix_slot.lock().unwrap() = None;
         let (ack, _) = tokio::sync::oneshot::channel();
-        let _ = self.handle.cmd.try_send(super::commands::Command::LeaveMix { ack });
+        let _ = self
+            .handle
+            .cmd
+            .try_send(super::commands::Command::LeaveMix { ack });
         true
     }
 }
@@ -544,7 +665,12 @@ pub struct DirectionOpts {
 /// Synchronous — index.js treats the return as the channel object directly,
 /// not a Promise. Bind sockets via std::net, hand over to the tokio actor.
 /// Events route to JS via ThreadsafeFunction so async tests resolve.
-type BindTuple = (std::net::UdpSocket, std::net::UdpSocket, SocketAddr, Option<crate::portpool::PortReservation>);
+type BindTuple = (
+    std::net::UdpSocket,
+    std::net::UdpSocket,
+    SocketAddr,
+    Option<crate::portpool::PortReservation>,
+);
 
 /// Bind RTP+RTCP from the managed port pool. The pool only hands out even
 /// ports and each is held exclusively, so both binds should always succeed
@@ -563,13 +689,26 @@ fn bind_from_pool() -> Result<BindTuple> {
         let rtcp_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port + 1);
         let rtp = match std::net::UdpSocket::bind(rtp_addr) {
             Ok(s) => s,
-            Err(e) => { last_err = Some(e); crate::portpool::release(port); continue; }
+            Err(e) => {
+                last_err = Some(e);
+                crate::portpool::release(port);
+                continue;
+            }
         };
         let rtcp = match std::net::UdpSocket::bind(rtcp_addr) {
             Ok(s) => s,
-            Err(e) => { last_err = Some(e); crate::portpool::release(port); continue; }
+            Err(e) => {
+                last_err = Some(e);
+                crate::portpool::release(port);
+                continue;
+            }
         };
-        return Ok((rtp, rtcp, rtp_addr, Some(crate::portpool::PortReservation::new(port))));
+        return Ok((
+            rtp,
+            rtcp,
+            rtp_addr,
+            Some(crate::portpool::PortReservation::new(port)),
+        ));
     }
     Err(Error::from_reason(format!(
         "bind rtp/rtcp from pool: exhausted {MAX_POOL_TRIES} tries; last={last_err:?}"
@@ -583,15 +722,29 @@ fn bind_ephemeral() -> Result<BindTuple> {
     for _ in 0..64 {
         let rtp = match std::net::UdpSocket::bind("0.0.0.0:0") {
             Ok(s) => s,
-            Err(e) => { last_err = Some(e); continue; }
+            Err(e) => {
+                last_err = Some(e);
+                continue;
+            }
         };
-        let la = match rtp.local_addr() { Ok(a) => a, Err(e) => { last_err = Some(e); continue; } };
+        let la = match rtp.local_addr() {
+            Ok(a) => a,
+            Err(e) => {
+                last_err = Some(e);
+                continue;
+            }
+        };
         let p = la.port();
-        if p % 2 != 0 { continue; }
+        if p % 2 != 0 {
+            continue;
+        }
         let rtcp_addr = SocketAddr::new(la.ip(), p + 1);
         match std::net::UdpSocket::bind(rtcp_addr) {
             Ok(rtcp) => return Ok((rtp, rtcp, la, None)),
-            Err(e) => { last_err = Some(e); continue; }
+            Err(e) => {
+                last_err = Some(e);
+                continue;
+            }
         }
     }
     Err(Error::from_reason(format!(
@@ -606,50 +759,87 @@ fn bind_ephemeral() -> Result<BindTuple> {
 fn parse_soundsoup(params: &Object) -> Option<super::player::SoundSoupSpec> {
     let files_arr: Array = params.get_named_property::<Array>("files").ok()?;
     let len = files_arr.len();
-    if len == 0 { return None; }
+    if len == 0 {
+        return None;
+    }
     let mut files = Vec::with_capacity(len as usize);
     for i in 0..len {
-        let Ok(entry) = files_arr.get::<Object>(i) else { continue; };
-        let Some(entry) = entry else { continue; };
-        let Ok(wav): Result<String> = entry.get_named_property("wav") else { continue; };
-        if wav.is_empty() { continue; }
+        let Ok(entry) = files_arr.get::<Object>(i) else {
+            continue;
+        };
+        let Some(entry) = entry else {
+            continue;
+        };
+        let Ok(wav): Result<String> = entry.get_named_property("wav") else {
+            continue;
+        };
+        if wav.is_empty() {
+            continue;
+        }
         let path = std::path::PathBuf::from(wav);
         // Skip entries whose file doesn't exist — matches C++
         // `soundsoup::load` which drops missing files silently and
         // (when every entry is missing) causes `channel.play()` to
         // return false. Tests assert the false return explicitly.
-        if !path.exists() { continue; }
+        if !path.exists() {
+            continue;
+        }
         // Per-file loop: JS accepts `true` (infinite — encoded as Some(0)
         // in player.rs) or a positive integer.
         let max_loops = if entry.get_named_property::<bool>("loop").ok() == Some(true) {
             Some(0)
         } else if let Ok(n) = entry.get_named_property::<u32>("loop") {
-            if n == 0 { None } else { Some(n) }
+            if n == 0 {
+                None
+            } else {
+                Some(n)
+            }
         } else {
             None
         };
         files.push(super::player::SoundSoupFileSpec {
             path,
-            start_ms: entry.get_named_property::<u32>("start").ok().filter(|&v| v > 0).map(|v| v as u64),
-            stop_ms: entry.get_named_property::<u32>("stop").ok().filter(|&v| v > 0).map(|v| v as u64),
+            start_ms: entry
+                .get_named_property::<u32>("start")
+                .ok()
+                .filter(|&v| v > 0)
+                .map(|v| v as u64),
+            stop_ms: entry
+                .get_named_property::<u32>("stop")
+                .ok()
+                .filter(|&v| v > 0)
+                .map(|v| v as u64),
             max_loops,
         });
     }
-    if files.is_empty() { return None; }
+    if files.is_empty() {
+        return None;
+    }
     // Top-level `loop`: bool (true → infinite, false/absent → once) or number
     // (explicit loop count). We can't know the JS type here, so try number
     // first then fall back to bool — matches how the C++ parser handles it.
     let overall_loops = if let Ok(n) = params.get_named_property::<u32>("loop") {
         // `loop: 0` means no looping in C++; treat as one-shot for parity.
-        if n == 0 { None } else { Some(n) }
+        if n == 0 {
+            None
+        } else {
+            Some(n)
+        }
     } else if params.get_named_property::<bool>("loop").ok() == Some(true) {
         Some(0) // 0 = infinite in player.rs
     } else {
         None
     };
     // Typo is intentional — C++ API uses "interupt".
-    let interrupt = params.get_named_property::<bool>("interupt").ok().unwrap_or(false);
-    Some(super::player::SoundSoupSpec { files, overall_loops, interrupt })
+    let interrupt = params
+        .get_named_property::<bool>("interupt")
+        .ok()
+        .unwrap_or(false);
+    Some(super::player::SoundSoupSpec {
+        files,
+        overall_loops,
+        interrupt,
+    })
 }
 
 /// Parse a JS `createWriteStream` params object into a `WriterConfig`.
@@ -671,12 +861,20 @@ fn parse_writer_config(params: &Object) -> super::audio_writer::WriterConfig {
 /// PCM at the channel's narrowband rate" case.
 fn parse_reader_config(params: &Object) -> super::audio_reader::ReaderConfig {
     use super::audio_reader::{ReaderConfig, ReaderDirection, ReaderFormat};
-    let direction = match params.get_named_property::<String>("direction").ok().as_deref() {
+    let direction = match params
+        .get_named_property::<String>("direction")
+        .ok()
+        .as_deref()
+    {
         Some("out") => ReaderDirection::Out,
         Some("both") => ReaderDirection::Both,
         _ => ReaderDirection::In,
     };
-    let format = match params.get_named_property::<String>("format").ok().as_deref() {
+    let format = match params
+        .get_named_property::<String>("format")
+        .ok()
+        .as_deref()
+    {
         Some("pcma") => ReaderFormat::Pcma,
         Some("pcmu") => ReaderFormat::Pcmu,
         Some("g722") => ReaderFormat::G722,
@@ -694,7 +892,12 @@ fn parse_reader_config(params: &Object) -> super::audio_reader::ReaderConfig {
         .filter(|&v| v == 1 || v == 2)
         .map(|v| v as u16)
         .unwrap_or(1);
-    ReaderConfig { direction, format, samplerate, num_channels }
+    ReaderConfig {
+        direction,
+        format,
+        samplerate,
+        num_channels,
+    }
 }
 
 /// Parse a JS `record` / `playrecord.record` params object into a
@@ -702,7 +905,9 @@ fn parse_reader_config(params: &Object) -> super::audio_reader::ReaderConfig {
 /// — the facade turns that into `record()`→false which tests assert.
 fn parse_recorder(params: &Object) -> Option<super::recorder::RecorderConfig> {
     let file: String = params.get_named_property::<String>("file").ok()?;
-    if file.is_empty() { return None; }
+    if file.is_empty() {
+        return None;
+    }
     // Default 2 channels matches the C++ recorder default — test/interface/
     // projectrtprecord.js "record to file" asserts channelcount === 2.
     let num_channels = params
@@ -715,12 +920,32 @@ fn parse_recorder(params: &Object) -> Option<super::recorder::RecorderConfig> {
         file: std::path::PathBuf::from(file),
         num_channels,
         sample_rate: 8000,
-        max_duration_ms: params.get_named_property::<u32>("maxduration").ok().filter(|&v| v > 0).map(|v| v as u64),
-        start_above_power: params.get_named_property::<i32>("startabovepower").ok().filter(|&v| v != 0),
-        finish_below_power: params.get_named_property::<i32>("finishbelowpower").ok().filter(|&v| v != 0),
-        max_since_start_power: params.get_named_property::<i32>("maxsincestartpower").ok().filter(|&v| v != 0),
-        min_duration_ms: params.get_named_property::<u32>("minduration").ok().filter(|&v| v > 0).map(|v| v as u64),
-        power_averaging_packets: params.get_named_property::<u32>("poweraveragepackets").ok().filter(|&v| v > 0),
+        max_duration_ms: params
+            .get_named_property::<u32>("maxduration")
+            .ok()
+            .filter(|&v| v > 0)
+            .map(|v| v as u64),
+        start_above_power: params
+            .get_named_property::<i32>("startabovepower")
+            .ok()
+            .filter(|&v| v != 0),
+        finish_below_power: params
+            .get_named_property::<i32>("finishbelowpower")
+            .ok()
+            .filter(|&v| v != 0),
+        max_since_start_power: params
+            .get_named_property::<i32>("maxsincestartpower")
+            .ok()
+            .filter(|&v| v != 0),
+        min_duration_ms: params
+            .get_named_property::<u32>("minduration")
+            .ok()
+            .filter(|&v| v > 0)
+            .map(|v| v as u64),
+        power_averaging_packets: params
+            .get_named_property::<u32>("poweraveragepackets")
+            .ok()
+            .filter(|&v| v > 0),
     })
 }
 
@@ -770,15 +995,23 @@ fn extract_rfc2833_pt(params: &Object) -> Option<u8> {
     {
         return Some(pt as u8);
     }
-    params.get_named_property::<u32>("rfc2833pt").ok().map(|v| v as u8)
+    params
+        .get_named_property::<u32>("rfc2833pt")
+        .ok()
+        .map(|v| v as u8)
 }
 
 /// Parse `params.direction = { send, recv }`. Both fields default to true.
 /// Tests use this to create write-only or read-only channels in a mix.
 fn extract_direction(params: &Object) -> super::commands::Direction {
     let d = params.get_named_property::<Object>("direction").ok();
-    let send = d.as_ref().and_then(|o| o.get_named_property::<bool>("send").ok()).unwrap_or(true);
-    let recv = d.and_then(|o| o.get_named_property::<bool>("recv").ok()).unwrap_or(true);
+    let send = d
+        .as_ref()
+        .and_then(|o| o.get_named_property::<bool>("send").ok())
+        .unwrap_or(true);
+    let recv = d
+        .and_then(|o| o.get_named_property::<bool>("recv").ok())
+        .unwrap_or(true);
     super::commands::Direction { send, recv }
 }
 
@@ -834,58 +1067,61 @@ pub fn open_channel(env: Env, params: Object, callback: JsFunction) -> Result<Ch
     let initial_remote_dtls = extract_remote_dtls(&params);
     let initial_direction = extract_direction(&params);
     let mut tsfn: ThreadsafeFunction<EventPayload, ErrorStrategy::Fatal> = callback
-        .create_threadsafe_function(0, |ctx: napi::threadsafe_function::ThreadSafeCallContext<EventPayload>| {
-            let ev = ctx.value;
-            let env = ctx.env;
-            let mut obj = env.create_object()?;
-            let action: napi::JsString = env.create_string(ev.action)?;
-            obj.set_named_property("action", action)?;
-            if let Some(r) = ev.reason {
-                let v: napi::JsString = env.create_string(&r)?;
-                obj.set_named_property("reason", v)?;
-            }
-            if let Some(e) = ev.event {
-                let v: napi::JsString = env.create_string(&e)?;
-                obj.set_named_property("event", v)?;
-            }
-            if let Some(s) = ev.state {
-                let v: napi::JsString = env.create_string(&s)?;
-                obj.set_named_property("state", v)?;
-            }
-            if let Some(f) = ev.file {
-                let v: napi::JsString = env.create_string(&f)?;
-                obj.set_named_property("file", v)?;
-            }
-            if let Some(fs) = ev.filesize {
-                obj.set_named_property("filesize", env.create_int64(fs as i64)?)?;
-            }
-            if let Some(stats) = ev.stats {
-                let mut s = env.create_object()?;
-                let mut in_o = env.create_object()?;
-                in_o.set_named_property("count",   env.create_int64(stats.in_count as i64)?)?;
-                in_o.set_named_property("dropped", env.create_int64(stats.in_dropped as i64)?)?;
-                in_o.set_named_property("skip",    env.create_int64(stats.in_skip as i64)?)?;
-                in_o.set_named_property("mos", env.create_double(stats.mos())?)?;
-                let mut out_o = env.create_object()?;
-                out_o.set_named_property("count", env.create_int64(stats.out_count as i64)?)?;
-                // Matches the C++ close-stats shape used by lib/node.js + the
-                // proxy tests that assert `msg.stats.{in,out,tick}` exist.
-                // Values are placeholders — we don't yet measure per-tick
-                // wall time the way the C++ addon does.
-                out_o.set_named_property("skip",  env.create_int64(0)?)?;
-                out_o.set_named_property("drop",  env.create_int64(0)?)?;
-                out_o.set_named_property("write", env.create_int64(stats.out_count as i64)?)?;
-                let mut tick_o = env.create_object()?;
-                tick_o.set_named_property("count",  env.create_int64(0)?)?;
-                tick_o.set_named_property("meanus", env.create_double(0.0)?)?;
-                tick_o.set_named_property("maxus",  env.create_double(0.0)?)?;
-                s.set_named_property("in", in_o)?;
-                s.set_named_property("out", out_o)?;
-                s.set_named_property("tick", tick_o)?;
-                obj.set_named_property("stats", s)?;
-            }
-            Ok(vec![obj])
-        })?;
+        .create_threadsafe_function(
+            0,
+            |ctx: napi::threadsafe_function::ThreadSafeCallContext<EventPayload>| {
+                let ev = ctx.value;
+                let env = ctx.env;
+                let mut obj = env.create_object()?;
+                let action: napi::JsString = env.create_string(ev.action)?;
+                obj.set_named_property("action", action)?;
+                if let Some(r) = ev.reason {
+                    let v: napi::JsString = env.create_string(&r)?;
+                    obj.set_named_property("reason", v)?;
+                }
+                if let Some(e) = ev.event {
+                    let v: napi::JsString = env.create_string(&e)?;
+                    obj.set_named_property("event", v)?;
+                }
+                if let Some(s) = ev.state {
+                    let v: napi::JsString = env.create_string(&s)?;
+                    obj.set_named_property("state", v)?;
+                }
+                if let Some(f) = ev.file {
+                    let v: napi::JsString = env.create_string(&f)?;
+                    obj.set_named_property("file", v)?;
+                }
+                if let Some(fs) = ev.filesize {
+                    obj.set_named_property("filesize", env.create_int64(fs as i64)?)?;
+                }
+                if let Some(stats) = ev.stats {
+                    let mut s = env.create_object()?;
+                    let mut in_o = env.create_object()?;
+                    in_o.set_named_property("count", env.create_int64(stats.in_count as i64)?)?;
+                    in_o.set_named_property("dropped", env.create_int64(stats.in_dropped as i64)?)?;
+                    in_o.set_named_property("skip", env.create_int64(stats.in_skip as i64)?)?;
+                    in_o.set_named_property("mos", env.create_double(stats.mos())?)?;
+                    let mut out_o = env.create_object()?;
+                    out_o.set_named_property("count", env.create_int64(stats.out_count as i64)?)?;
+                    // Matches the C++ close-stats shape used by lib/node.js + the
+                    // proxy tests that assert `msg.stats.{in,out,tick}` exist.
+                    // Values are placeholders — we don't yet measure per-tick
+                    // wall time the way the C++ addon does.
+                    out_o.set_named_property("skip", env.create_int64(0)?)?;
+                    out_o.set_named_property("drop", env.create_int64(0)?)?;
+                    out_o.set_named_property("write", env.create_int64(stats.out_count as i64)?)?;
+                    let mut tick_o = env.create_object()?;
+                    tick_o.set_named_property("count", env.create_int64(0)?)?;
+                    tick_o.set_named_property("meanus", env.create_double(0.0)?)?;
+                    tick_o.set_named_property("maxus", env.create_double(0.0)?)?;
+                    s.set_named_property("in", in_o)?;
+                    s.set_named_property("out", out_o)?;
+                    s.set_named_property("tick", tick_o)?;
+                    obj.set_named_property("stats", s)?;
+                }
+                Ok(vec![obj])
+            },
+        )?;
     // Unref the TSFN so it doesn't keep the Node.js event loop alive.
     // Without this, the process hangs on shutdown because each channel's
     // TSFN holds a libuv handle that prevents the event loop from draining.
@@ -940,7 +1176,9 @@ pub fn open_channel(env: Env, params: Object, callback: JsFunction) -> Result<Ch
     // else so the channel observes the right send/recv flags on its first
     // tick. Skip the send if the user didn't override the defaults.
     if initial_direction.send != true || initial_direction.recv != true {
-        let _ = handle.cmd.try_send(super::commands::Command::Direction(initial_direction));
+        let _ = handle
+            .cmd
+            .try_send(super::commands::Command::Direction(initial_direction));
     }
 
     // If params.remote was supplied, enqueue a Remote command
@@ -985,7 +1223,10 @@ pub fn open_channel(env: Env, params: Object, callback: JsFunction) -> Result<Ch
 
 fn rand_ssrc() -> u32 {
     use std::time::{SystemTime, UNIX_EPOCH};
-    let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
     (t as u32) ^ (NEXT_CHANNEL_ID.load(Ordering::Relaxed) as u32).wrapping_mul(0x9E37_79B1)
 }
 
@@ -994,11 +1235,15 @@ fn rand_ssrc() -> u32 {
 /// ICE binding purposes; revisit when DTLS-SRTP wiring lands.
 fn rand_icepwd() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
-    const ALPHABET: &[u8] =
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     let mut s = String::with_capacity(24);
-    let mut seed = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos() as u64
-        ^ NEXT_CHANNEL_ID.load(Ordering::Relaxed).wrapping_mul(0xA5A5_5A5A);
+    let mut seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
+        ^ NEXT_CHANNEL_ID
+            .load(Ordering::Relaxed)
+            .wrapping_mul(0xA5A5_5A5A);
     for _ in 0..24 {
         // xorshift64
         seed ^= seed << 13;

--- a/rust/src/channel/jitter.rs
+++ b/rust/src/channel/jitter.rs
@@ -54,9 +54,13 @@ impl JitterBuffer {
         }
     }
 
-    pub fn size(&self) -> usize { self.buffer_count }
+    pub fn size(&self) -> usize {
+        self.buffer_count
+    }
     #[allow(dead_code)]
-    pub fn out_sn(&self) -> u16 { self.out_sn }
+    pub fn out_sn(&self) -> u16 {
+        self.out_sn
+    }
 
     /// Insert a packet. Caller has populated sequence_number etc.
     pub fn push(&mut self, pk: RtpPacket) {
@@ -100,7 +104,9 @@ impl JitterBuffer {
     /// Peek the next in-order packet without advancing. If the slot is empty
     /// or holds a stale SN, advances out_sn past it and returns None.
     pub fn peek(&mut self) -> Option<&RtpPacket> {
-        if !self.primed { return None; }
+        if !self.primed {
+            return None;
+        }
         let idx = (self.out_sn as usize) % self.buffer_count;
         match &self.slots[idx] {
             None => {
@@ -142,7 +148,9 @@ impl JitterBuffer {
     }
 
     pub fn clear(&mut self) {
-        for slot in self.slots.iter_mut() { *slot = None; }
+        for slot in self.slots.iter_mut() {
+            *slot = None;
+        }
         self.peeked_slot = None;
         self.primed = false;
     }
@@ -178,13 +186,15 @@ mod tests {
     #[test]
     fn out_of_order_reorders() {
         let mut b = JitterBuffer::new(32, 2);
-        b.push(mkpk(500));   // primes out_sn = 498
+        b.push(mkpk(500)); // primes out_sn = 498
         b.push(mkpk(502));
         b.push(mkpk(501));
         b.push(mkpk(503));
         let mut seen = Vec::new();
         for _ in 0..20 {
-            if let Some(p) = b.pop() { seen.push(p.sequence_number()); }
+            if let Some(p) = b.pop() {
+                seen.push(p.sequence_number());
+            }
         }
         assert_eq!(seen, vec![500, 501, 502, 503]);
     }
@@ -193,7 +203,7 @@ mod tests {
     fn over_buffer_range_drops() {
         let mut b = JitterBuffer::new(32, 2);
         b.push(mkpk(100));
-        b.push(mkpk(20_000));   // absurdly ahead → dropped
+        b.push(mkpk(20_000)); // absurdly ahead → dropped
         assert!(b.dropped >= 1);
     }
 
@@ -206,7 +216,9 @@ mod tests {
         b.push(mkpk(103));
         let mut seen = Vec::new();
         for _ in 0..10 {
-            if let Some(p) = b.pop() { seen.push(p.sequence_number()); }
+            if let Some(p) = b.pop() {
+                seen.push(p.sequence_number());
+            }
         }
         assert!(seen.contains(&100));
         assert!(seen.contains(&101));
@@ -219,11 +231,13 @@ mod tests {
         let mut b = JitterBuffer::new(32, 2);
         b.push(mkpk(u16::MAX - 1));
         b.push(mkpk(u16::MAX));
-        b.push(mkpk(0));   // wrapped
+        b.push(mkpk(0)); // wrapped
         b.push(mkpk(1));
         let mut seen = Vec::new();
         for _ in 0..20 {
-            if let Some(p) = b.pop() { seen.push(p.sequence_number()); }
+            if let Some(p) = b.pop() {
+                seen.push(p.sequence_number());
+            }
         }
         assert_eq!(seen, vec![u16::MAX - 1, u16::MAX, 0, 1]);
     }
@@ -232,15 +246,27 @@ mod tests {
     fn restart_at_different_sn_after_drain() {
         let mut b = JitterBuffer::new(32, 10);
         // Push 15, drain all.
-        for sn in 256..271 { b.push(mkpk(sn)); }
+        for sn in 256..271 {
+            b.push(mkpk(sn));
+        }
         let mut seen = Vec::new();
-        for _ in 0..30 { if let Some(p) = b.pop() { seen.push(p.sequence_number()); } }
+        for _ in 0..30 {
+            if let Some(p) = b.pop() {
+                seen.push(p.sequence_number());
+            }
+        }
         assert_eq!(seen.len(), 15);
 
         // Restart from a much higher SN — should re-prime, not drop.
-        for sn in 512..522 { b.push(mkpk(sn)); }
+        for sn in 512..522 {
+            b.push(mkpk(sn));
+        }
         let mut seen2 = Vec::new();
-        for _ in 0..30 { if let Some(p) = b.pop() { seen2.push(p.sequence_number()); } }
+        for _ in 0..30 {
+            if let Some(p) = b.pop() {
+                seen2.push(p.sequence_number());
+            }
+        }
         assert_eq!(seen2, (512..522).collect::<Vec<_>>());
     }
 }

--- a/rust/src/channel/mixer.rs
+++ b/rust/src/channel/mixer.rs
@@ -35,8 +35,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{interval, MissedTickBehavior};
 
 use super::actor::{
-    activate_pending_recorder, Event, EventSink, PlayState, RecordState, Subsystems, TICK_MS,
-    PREBUFFER_CAPACITY_SAMPLES,
+    activate_pending_recorder, Event, EventSink, PlayState, RecordState, Subsystems,
+    PREBUFFER_CAPACITY_SAMPLES, TICK_MS,
 };
 use super::commands::{ChannelId, Command};
 use super::player::Player;
@@ -60,11 +60,7 @@ pub struct Member {
 }
 
 impl Member {
-    pub fn new(
-        state: Box<ChannelState>,
-        subs: Subsystems,
-        events: Arc<dyn EventSink>,
-    ) -> Self {
+    pub fn new(state: Box<ChannelState>, subs: Subsystems, events: Arc<dyn EventSink>) -> Self {
         Self {
             state,
             subs,
@@ -77,9 +73,18 @@ impl Member {
 }
 
 pub enum MixerCommand {
-    Add { member: Box<Member>, ack: oneshot::Sender<()> },
-    Remove { id: ChannelId, ack: oneshot::Sender<Option<Box<Member>>> },
-    Forward { id: ChannelId, cmd: Command },
+    Add {
+        member: Box<Member>,
+        ack: oneshot::Sender<()>,
+    },
+    Remove {
+        id: ChannelId,
+        ack: oneshot::Sender<Option<Box<Member>>>,
+    },
+    Forward {
+        id: ChannelId,
+        cmd: Command,
+    },
     #[allow(dead_code)]
     Stop,
 }
@@ -95,13 +100,19 @@ pub struct MixHandle {
 impl MixHandle {
     pub async fn add(&self, member: Box<Member>) -> Result<(), ()> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(MixerCommand::Add { member, ack: tx }).await.map_err(|_| ())?;
+        self.cmd
+            .send(MixerCommand::Add { member, ack: tx })
+            .await
+            .map_err(|_| ())?;
         rx.await.map_err(|_| ())
     }
 
     pub async fn remove(&self, id: ChannelId) -> Option<Box<Member>> {
         let (tx, rx) = oneshot::channel();
-        self.cmd.send(MixerCommand::Remove { id, ack: tx }).await.ok()?;
+        self.cmd
+            .send(MixerCommand::Remove { id, ack: tx })
+            .await
+            .ok()?;
         rx.await.ok().flatten()
     }
 
@@ -177,8 +188,12 @@ async fn run(mut cmds: mpsc::Receiver<MixerCommand>) {
 /// the wrong key.
 async fn mix2_outbound(members: &mut HashMap<ChannelId, Box<Member>>) {
     let mut iter = members.iter_mut();
-    let Some((_, first)) = iter.next() else { return; };
-    let Some((_, second)) = iter.next() else { return; };
+    let Some((_, first)) = iter.next() else {
+        return;
+    };
+    let Some((_, second)) = iter.next() else {
+        return;
+    };
     // Peel the `Box<Member>` so we work with two `&mut Member`s.
     let (a, b): (&mut Member, &mut Member) = (first, second);
 
@@ -199,12 +214,20 @@ async fn mix2_outbound(members: &mut HashMap<ChannelId, Box<Member>>) {
 /// The encoder state (G.722 predictor, iLBC LP, up-sample filter)
 /// persists on `dst.state.codecx` for a coherent outbound stream.
 async fn send_leg(src: &mut Member, dst: &mut Member) {
-    if !src.state.direction.send { return; }
-    if !src.frame_present { return; }
-    let Some(dest_addr) = dst.state.get_remote_addr() else { return; };
+    if !src.state.direction.send {
+        return;
+    }
+    if !src.frame_present {
+        return;
+    }
+    let Some(dest_addr) = dst.state.get_remote_addr() else {
+        return;
+    };
     let peer_pt = dst.state.remote_pt;
 
-    let Some(wire) = dst.state.codecx.encode_from(peer_pt, &mut src.state.codecx) else { return; };
+    let Some(wire) = dst.state.codecx.encode_from(peer_pt, &mut src.state.codecx) else {
+        return;
+    };
     // Owned copy so the `&mut dst.state.codecx` borrow ends before the
     // `&mut dst.state` borrows later for the RTP send.
     let payload: Vec<u8> = wire.to_vec();
@@ -221,11 +244,20 @@ async fn send_leg(src: &mut Member, dst: &mut Member) {
 
     let send_ok = if let Some(ref mut ctx) = dst.state.srtp_encrypt {
         match ctx.encrypt_rtp(pkt.as_slice()) {
-            Ok(encrypted) => dst.state.rtp_sock.send_to(&encrypted, dest_addr).await.is_ok(),
+            Ok(encrypted) => dst
+                .state
+                .rtp_sock
+                .send_to(&encrypted, dest_addr)
+                .await
+                .is_ok(),
             Err(_) => false,
         }
     } else {
-        dst.state.rtp_sock.send_to(pkt.as_slice(), dest_addr).await.is_ok()
+        dst.state
+            .rtp_sock
+            .send_to(pkt.as_slice(), dest_addr)
+            .await
+            .is_ok()
     };
     if send_ok {
         dst.state.out_count += 1;
@@ -240,16 +272,24 @@ async fn mix_all_outbound(members: &mut HashMap<ChannelId, Box<Member>>) {
     // Sum all members' frames into a single int32 buffer.
     let mut summed = vec![0i32; MIX_FRAME_SAMPLES];
     for m in members.values() {
-        if !m.state.direction.recv { continue; }
-        if !m.frame_present { continue; }
+        if !m.state.direction.recv {
+            continue;
+        }
+        if !m.frame_present {
+            continue;
+        }
         for (slot, &sample) in summed.iter_mut().zip(m.frame.iter()) {
             *slot = slot.saturating_add(sample as i32);
         }
     }
 
     for m in members.values_mut() {
-        if !m.state.direction.send { continue; }
-        let Some(remote) = m.state.get_remote_addr() else { continue; };
+        if !m.state.direction.send {
+            continue;
+        }
+        let Some(remote) = m.state.get_remote_addr() else {
+            continue;
+        };
 
         let mut out_samples = vec![0i16; MIX_FRAME_SAMPLES];
         if m.frame_present {
@@ -289,7 +329,9 @@ impl Member {
     /// zeroed so silent inbound doesn't leak last tick's audio into the
     /// mix output.
     fn reset_for_tick(&mut self) {
-        for s in self.frame.iter_mut() { *s = 0; }
+        for s in self.frame.iter_mut() {
+            *s = 0;
+        }
         self.frame_present = false;
         self.inbound_this_tick = false;
     }
@@ -299,9 +341,7 @@ impl Member {
     /// or if decryption fails.
     fn pop_inbound(&mut self) -> Option<RtpPacket> {
         let mut popped = self.state.jitter.lock().pop();
-        if let (Some(ref mut pk), Some(ref mut ctx)) =
-            (&mut popped, &mut self.state.srtp_decrypt)
-        {
+        if let (Some(ref mut pk), Some(ref mut ctx)) = (&mut popped, &mut self.state.srtp_decrypt) {
             match ctx.decrypt_rtp(pk.as_slice()) {
                 Ok(decrypted) => {
                     let n = decrypted.len().min(pk.buf.len());
@@ -335,11 +375,11 @@ impl Member {
                 activate_recorder = true;
             }
         }
-        self.state.pending_events.push(Event::TelephoneEvent { digit });
+        self.state
+            .pending_events
+            .push(Event::TelephoneEvent { digit });
         if activate_recorder {
-            let _ = activate_pending_recorder(
-                &mut self.subs, &mut self.state.pending_events,
-            ).await;
+            let _ = activate_pending_recorder(&mut self.subs, &mut self.state.pending_events).await;
         }
         Some(digit)
     }
@@ -366,9 +406,7 @@ impl Member {
             }
         }
         if player_just_ended {
-            let _ = activate_pending_recorder(
-                &mut self.subs, &mut self.state.pending_events,
-            ).await;
+            let _ = activate_pending_recorder(&mut self.subs, &mut self.state.pending_events).await;
         }
         player_frame
     }
@@ -377,7 +415,9 @@ impl Member {
     /// (matches C++ relay semantics — the far end's audio is what should
     /// be mixed, not our own playback).
     fn populate_mix_frame(&mut self, inbound: Option<&[i16]>, player: Option<&[i16]>) {
-        if !self.state.direction.recv { return; }
+        if !self.state.direction.recv {
+            return;
+        }
         if let Some(samples) = inbound {
             copy_into_frame(&mut self.frame, samples);
             self.frame_present = true;
@@ -391,20 +431,33 @@ impl Member {
     /// Barge-in on inbound power. Fires a player-end event and activates
     /// a queued recorder when the smoothed RMS crosses the threshold.
     async fn run_bargein(&mut self, inbound: Option<&[i16]>) {
-        let Some(samples) = inbound else { return; };
-        let Some(bi) = self.subs.bargein.as_mut() else { return; };
-        if self.subs.player.is_none() { return; }
-        if self.state.in_count.load(Ordering::Relaxed) < 100 { return; }
+        let Some(samples) = inbound else {
+            return;
+        };
+        let Some(bi) = self.subs.bargein.as_mut() else {
+            return;
+        };
+        if self.subs.player.is_none() {
+            return;
+        }
+        if self.state.in_count.load(Ordering::Relaxed) < 100 {
+            return;
+        }
 
         let mut sum_sq: u64 = 0;
         for s in samples {
             let v = *s as i64;
             sum_sq += (v * v) as u64;
         }
-        let rms = if samples.is_empty() { 0 }
-                  else { ((sum_sq / samples.len() as u64) as f64).sqrt() as i32 };
+        let rms = if samples.is_empty() {
+            0
+        } else {
+            ((sum_sq / samples.len() as u64) as f64).sqrt() as i32
+        };
         let smoothed = bi.power_ma.execute(rms.min(i16::MAX as i32) as i16) as i32;
-        if smoothed <= bi.power_threshold { return; }
+        if smoothed <= bi.power_threshold {
+            return;
+        }
 
         self.subs.player = None;
         self.subs.bargein = None;
@@ -412,17 +465,19 @@ impl Member {
             state: PlayState::End,
             reason: Some("interrupted".into()),
         });
-        let _ = activate_pending_recorder(
-            &mut self.subs, &mut self.state.pending_events,
-        ).await;
+        let _ = activate_pending_recorder(&mut self.subs, &mut self.state.pending_events).await;
     }
 
     /// While `playrecord` is in its play phase (player active AND
     /// recorder queued), accumulate inbound samples into `prebuffer`.
     /// Drops oldest samples when the cap is hit.
     fn accumulate_playrecord_prebuffer(&mut self, inbound: Option<&[i16]>) {
-        if self.subs.player.is_none() || self.subs.pending_recorder.is_none() { return; }
-        let Some(samples) = inbound else { return; };
+        if self.subs.player.is_none() || self.subs.pending_recorder.is_none() {
+            return;
+        }
+        let Some(samples) = inbound else {
+            return;
+        };
 
         if self.subs.prebuffer.len() + samples.len() > PREBUFFER_CAPACITY_SAMPLES {
             let drop_n = self.subs.prebuffer.len() + samples.len() - PREBUFFER_CAPACITY_SAMPLES;
@@ -430,7 +485,9 @@ impl Member {
                 self.subs.prebuffer.pop_front();
             }
         }
-        for s in samples { self.subs.prebuffer.push_back(*s); }
+        for s in samples {
+            self.subs.prebuffer.push_back(*s);
+        }
     }
 
     /// Feed active recorders the inbound 8 kHz linear samples for this
@@ -459,8 +516,7 @@ impl Member {
         // a packet ends up being sent for this leg. send_leg/send_encoded
         // no longer advance it themselves. See tick::run for the same
         // reasoning.
-        self.state.out_ts =
-            self.state.out_ts.wrapping_add(MIX_FRAME_SAMPLES as u32);
+        self.state.out_ts = self.state.out_ts.wrapping_add(MIX_FRAME_SAMPLES as u32);
 
         // Build SRTP contexts as soon as the DTLS handshake completes.
         // In Local mode this runs via `tick::run`; in the mixer the
@@ -479,7 +535,9 @@ impl Member {
         let mut popped_any = false;
         let mut last_dtmf_digit: Option<char> = None;
         loop {
-            let Some(pk) = self.pop_inbound() else { break; };
+            let Some(pk) = self.pop_inbound() else {
+                break;
+            };
             popped_any = true;
             if pk.payload_type() == self.state.rfc2833_pt {
                 if let Some(d) = self.handle_dtmf_in(&pk).await {
@@ -516,10 +574,15 @@ impl Member {
         // calls `require_narrowband_8k` triggers it; subsequent callers
         // share the cached result.
         if let Some(in_pk) = popped.as_ref() {
-            self.state.codecx.feed_wire(in_pk.payload_type(), in_pk.payload());
+            self.state
+                .codecx
+                .feed_wire(in_pk.payload_type(), in_pk.payload());
         }
         let inbound: Option<Vec<i16>> = if popped.is_some() {
-            self.state.codecx.require_narrowband_8k().map(|s| s.to_vec())
+            self.state
+                .codecx
+                .require_narrowband_8k()
+                .map(|s| s.to_vec())
         } else {
             None
         };
@@ -560,7 +623,11 @@ impl Member {
             let w = self.subs.writer.as_mut()?;
             w.next_frame_8k()
         };
-        let drained = self.subs.writer.as_ref().is_some_and(|w| w.is_drained_and_ended());
+        let drained = self
+            .subs
+            .writer
+            .as_ref()
+            .is_some_and(|w| w.is_drained_and_ended());
         if drained {
             self.subs.writer = None;
             self.state.pending_events.push(Event::Play {
@@ -577,9 +644,22 @@ impl Member {
     /// R=far leg) — matches C++ mix recording semantics. When `None`
     /// (Local mode, N≥3, or peer had no inbound this tick) stereo
     /// falls back to duplicate-mono.
-    async fn write_recordings(&mut self, peer_samples: Option<&[i16]>, peer_wideband: Option<&[i16]>) {
-        if !self.inbound_this_tick { return; }
-        let Some(samples) = self.state.codecx.require_narrowband_8k().map(|s| s.to_vec()) else { return; };
+    async fn write_recordings(
+        &mut self,
+        peer_samples: Option<&[i16]>,
+        peer_wideband: Option<&[i16]>,
+    ) {
+        if !self.inbound_this_tick {
+            return;
+        }
+        let Some(samples) = self
+            .state
+            .codecx
+            .require_narrowband_8k()
+            .map(|s| s.to_vec())
+        else {
+            return;
+        };
         let self_wb = if self.state.codecx.is_wideband() {
             self.state.codecx.require_wideband_16k().map(|s| s.to_vec())
         } else {
@@ -596,9 +676,13 @@ impl Member {
             None => (&samples, peer_samples),
         };
         feed_recorders(
-            &mut self.subs.recorders, rec_self, rec_peer, ch_count,
+            &mut self.subs.recorders,
+            rec_self,
+            rec_peer,
+            ch_count,
             &mut self.state.pending_events,
-        ).await;
+        )
+        .await;
 
         // AudioReaders share the recorder's L/R convention (L=self inbound,
         // R=peer inbound — in mix mode that's the outbound side). Readers
@@ -606,7 +690,12 @@ impl Member {
         // wideband from codecx), and a 16k reader's out side gets the peer's
         // wideband via feed_with.
         for reader in self.subs.readers.iter_mut() {
-            reader.feed_with(&mut self.state.codecx, Some(&samples), peer_samples, peer_wideband);
+            reader.feed_with(
+                &mut self.state.codecx,
+                Some(&samples),
+                peer_samples,
+                peer_wideband,
+            );
         }
         self.subs.readers.retain(|r| !r.is_closed());
     }
@@ -622,8 +711,12 @@ impl Member {
     /// `out_ts` on every intervening tick. RFC 2833 requires constant
     /// TS per burst — strict receivers otherwise see 14 ghost events.
     async fn send_dtmf_outbound(&mut self) {
-        if !self.state.direction.send { return; }
-        let Some(remote) = self.state.get_remote_addr() else { return; };
+        if !self.state.direction.send {
+            return;
+        }
+        let Some(remote) = self.state.get_remote_addr() else {
+            return;
+        };
         let pt = self.state.rfc2833_pt;
         if let Some(pkt) = self.subs.dtmf_send.next_event(self.state.out_ts) {
             send_dtmf_to_remote(&mut self.state, remote, pt, &pkt).await;
@@ -644,7 +737,7 @@ impl Member {
 
     /// Multi-tier idle check matching C++ `checkidlerecv`.
     fn is_idle(&self) -> bool {
-        use super::tick::{IDLE_TICK_LIMIT, HARD_TIMEOUT_NO_REMOTE, HARD_TIMEOUT_NO_RECV};
+        use super::tick::{HARD_TIMEOUT_NO_RECV, HARD_TIMEOUT_NO_REMOTE, IDLE_TICK_LIMIT};
         if self.state.direction.recv {
             if self.state.remote_confirmed {
                 self.state.ticks_without_rtp >= IDLE_TICK_LIMIT
@@ -732,10 +825,7 @@ async fn run_inbound_phase(
 /// For N=2, stereo recorders need each member's peer samples — computed
 /// once up-front so every member can read its sibling's narrowband
 /// without reborrowing.
-async fn run_post_mix_phase(
-    members: &mut HashMap<ChannelId, Box<Member>>,
-    n_alive: usize,
-) {
+async fn run_post_mix_phase(members: &mut HashMap<ChannelId, Box<Member>>, n_alive: usize) {
     let peer_samples_by_id = compute_peer_samples_by_id(members, n_alive);
     let peer_wideband_by_id = compute_peer_wideband_by_id(members, n_alive);
 
@@ -747,22 +837,27 @@ async fn run_post_mix_phase(
             // Always Some in N=2 — silence fallback when the peer had
             // no inbound this tick; never None (which would trigger
             // duplicate-mono in the stereo recorder).
-            peer_samples_by_id.iter()
+            peer_samples_by_id
+                .iter()
                 .find_map(|(&pid, s)| if pid != id { Some(s.clone()) } else { None })
-                .or_else(|| Some(vec![ 0i16; MIX_FRAME_SAMPLES ]))
+                .or_else(|| Some(vec![0i16; MIX_FRAME_SAMPLES]))
         } else {
             None
         };
         // 16k wideband counterpart for the reader tap's out side (320 samples).
         let peer_wideband: Option<Vec<i16>> = if n_alive == 2 {
-            peer_wideband_by_id.iter()
+            peer_wideband_by_id
+                .iter()
                 .find_map(|(&pid, s)| if pid != id { Some(s.clone()) } else { None })
-                .or_else(|| Some(vec![ 0i16; MIX_FRAME_SAMPLES * 2 ]))
+                .or_else(|| Some(vec![0i16; MIX_FRAME_SAMPLES * 2]))
         } else {
             None
         };
-        let Some(m) = members.get_mut(&id) else { continue; };
-        m.write_recordings(peer_samples.as_deref(), peer_wideband.as_deref()).await;
+        let Some(m) = members.get_mut(&id) else {
+            continue;
+        };
+        m.write_recordings(peer_samples.as_deref(), peer_wideband.as_deref())
+            .await;
         m.send_dtmf_outbound().await;
         m.drain_pending_events();
     }
@@ -780,14 +875,17 @@ fn compute_peer_samples_by_id(
     if n_alive != 2 {
         return HashMap::new();
     }
-    members.iter_mut()
+    members
+        .iter_mut()
         .map(|(&id, m)| {
             let samples = if m.inbound_this_tick {
-                m.state.codecx.require_narrowband_8k()
+                m.state
+                    .codecx
+                    .require_narrowband_8k()
                     .map(|s| s.to_vec())
-                    .unwrap_or_else(|| vec![ 0i16; MIX_FRAME_SAMPLES ])
+                    .unwrap_or_else(|| vec![0i16; MIX_FRAME_SAMPLES])
             } else {
-                vec![ 0i16; MIX_FRAME_SAMPLES ]
+                vec![0i16; MIX_FRAME_SAMPLES]
             };
             (id, samples)
         })
@@ -806,14 +904,17 @@ fn compute_peer_wideband_by_id(
     if n_alive != 2 {
         return HashMap::new();
     }
-    members.iter_mut()
+    members
+        .iter_mut()
         .map(|(&id, m)| {
             let samples = if m.inbound_this_tick {
-                m.state.codecx.require_wideband_16k()
+                m.state
+                    .codecx
+                    .require_wideband_16k()
                     .map(|s| s.to_vec())
-                    .unwrap_or_else(|| vec![ 0i16; MIX_FRAME_SAMPLES * 2 ])
+                    .unwrap_or_else(|| vec![0i16; MIX_FRAME_SAMPLES * 2])
             } else {
-                vec![ 0i16; MIX_FRAME_SAMPLES * 2 ]
+                vec![0i16; MIX_FRAME_SAMPLES * 2]
             };
             (id, samples)
         })
@@ -824,8 +925,11 @@ fn compute_peer_wideband_by_id(
 /// (when dynamic, i.e. ≥96) so the bridge can decode/encode at the
 /// right PT on both sides of an asymmetric-dynamic pair.
 fn configure_peer_ilbc_pts(members: &mut HashMap<ChannelId, Box<Member>>, n_alive: usize) {
-    if n_alive != 2 { return; }
-    let pts: Vec<(ChannelId, u8)> = members.iter()
+    if n_alive != 2 {
+        return;
+    }
+    let pts: Vec<(ChannelId, u8)> = members
+        .iter()
         .map(|(&id, m)| (id, m.state.remote_pt))
         .collect();
     for (&id, m) in members.iter_mut() {
@@ -846,7 +950,9 @@ fn broadcast_dtmf_to_peer_relays(
     for (origin, digit) in digits {
         let digit_str = digit.to_string();
         for (&id, m) in members.iter_mut() {
-            if id == *origin { continue; }
+            if id == *origin {
+                continue;
+            }
             m.subs.dtmf_relay.enqueue(&digit_str);
         }
     }
@@ -854,7 +960,8 @@ fn broadcast_dtmf_to_peer_relays(
 
 /// Remove idle members from the mix and emit each one's Close event.
 fn close_idle_members(members: &mut HashMap<ChannelId, Box<Member>>) {
-    let idle_ids: Vec<ChannelId> = members.iter()
+    let idle_ids: Vec<ChannelId> = members
+        .iter()
         .filter(|(_, m)| m.is_idle())
         .map(|(&id, _)| id)
         .collect();
@@ -870,7 +977,9 @@ fn close_idle_members(members: &mut HashMap<ChannelId, Box<Member>>) {
 fn copy_into_frame(dst: &mut [i16], src: &[i16]) {
     let n = src.len().min(dst.len());
     dst[..n].copy_from_slice(&src[..n]);
-    for s in &mut dst[n..] { *s = 0; }
+    for s in &mut dst[n..] {
+        *s = 0;
+    }
 }
 
 /// Feed every active recorder on this channel one tick's worth of audio.
@@ -910,7 +1019,10 @@ async fn feed_recorders(
                 }
                 None => {
                     // No peer available — duplicate-mono fallback.
-                    for &s in samples { inter.push(s); inter.push(s); }
+                    for &s in samples {
+                        inter.push(s);
+                        inter.push(s);
+                    }
                 }
             }
             inter
@@ -919,17 +1031,23 @@ async fn feed_recorders(
             // `soundfilewriter::write` where mono advances buf by 1 in
             // both loops so the second leg is `*buf += outval`.
             match peer_samples {
-                Some(peer) => samples.iter().enumerate().map(|(idx, &s)| {
-                    let a = s as i32;
-                    let b = peer.get(idx).copied().unwrap_or(0) as i32;
-                    (a + b).clamp(i16::MIN as i32, i16::MAX as i32) as i16
-                }).collect(),
+                Some(peer) => samples
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, &s)| {
+                        let a = s as i32;
+                        let b = peer.get(idx).copied().unwrap_or(0) as i32;
+                        (a + b).clamp(i16::MIN as i32, i16::MAX as i32) as i16
+                    })
+                    .collect(),
                 None => samples.to_vec(),
             }
         };
         // Power calc on the narrowband `samples` (self's inbound), not
         // the interleaved stereo `frame` — matches C++ `codecx::power()`.
-        let _ = rec.write_frame(&frame, samples, Some(channel_in_count)).await;
+        let _ = rec
+            .write_frame(&frame, samples, Some(channel_in_count))
+            .await;
         let new_state = rec.state();
         let file_str = rec.file().to_string_lossy().into_owned();
         if prev_state == RecorderState::Pending && new_state == RecorderState::Active {
@@ -963,7 +1081,6 @@ async fn feed_recorders(
         i += 1;
     }
 }
-
 
 async fn send_rtp(state: &mut ChannelState, pkt: &RtpPacket, remote: SocketAddr) {
     if let Some(ref mut ctx) = state.srtp_encrypt {
@@ -1013,9 +1130,15 @@ async fn send_dtmf_to_remote(
 
 async fn apply_forwarded(m: &mut Member, cmd: Command) {
     match cmd {
-        Command::Direction(d) => { m.state.direction = d; }
-        Command::Echo { enabled } => { m.state.echo = enabled; }
-        Command::Dtmf { digits } => { m.subs.dtmf_send.enqueue(&digits); }
+        Command::Direction(d) => {
+            m.state.direction = d;
+        }
+        Command::Echo { enabled } => {
+            m.state.echo = enabled;
+        }
+        Command::Dtmf { digits } => {
+            m.subs.dtmf_send.enqueue(&digits);
+        }
         Command::Remote { cfg, ack } => {
             m.state.set_remote_addr(cfg.addr);
             m.state.remote_pt = cfg.payload_type;
@@ -1063,7 +1186,12 @@ async fn apply_forwarded(m: &mut Member, cmd: Command) {
             // If an existing recorder at the same path is paused, resume it
             // instead of replacing it. This preserves the recording file so
             // both segments end up in one WAV.
-            if let Some(rec) = m.subs.recorders.iter_mut().find(|r| r.file() == cfg.file && r.state() == RecorderState::Paused) {
+            if let Some(rec) = m
+                .subs
+                .recorders
+                .iter_mut()
+                .find(|r| r.file() == cfg.file && r.state() == RecorderState::Paused)
+            {
                 rec.resume();
                 m.events.post(Event::Record {
                     state: RecordState::Recording,
@@ -1072,43 +1200,47 @@ async fn apply_forwarded(m: &mut Member, cmd: Command) {
                     filesize: None,
                 });
             } else {
-            match Recorder::open(cfg.clone()).await {
-                Ok(rec) => {
-                    if let Some(idx) = m.subs.recorders.iter().position(|r| r.file() == rec.file()) {
-                        let mut old = m.subs.recorders.remove(idx);
-                        let size = old.file_size();
-                        old.close(FinishReason::ChannelClosed);
+                match Recorder::open(cfg.clone()).await {
+                    Ok(rec) => {
+                        if let Some(idx) =
+                            m.subs.recorders.iter().position(|r| r.file() == rec.file())
+                        {
+                            let mut old = m.subs.recorders.remove(idx);
+                            let size = old.file_size();
+                            old.close(FinishReason::ChannelClosed);
+                            m.events.post(Event::Record {
+                                state: RecordState::Finished,
+                                reason: Some("channelclosed".into()),
+                                file: Some(file_str.clone()),
+                                filesize: Some(size),
+                            });
+                        }
+                        m.subs.recorders.push(rec);
+                        if !is_gated {
+                            m.events.post(Event::Record {
+                                state: RecordState::Recording,
+                                reason: None,
+                                file: Some(file_str),
+                                filesize: None,
+                            });
+                        }
+                    }
+                    Err(e) => {
                         m.events.post(Event::Record {
                             state: RecordState::Finished,
-                            reason: Some("channelclosed".into()),
-                            file: Some(file_str.clone()),
-                            filesize: Some(size),
-                        });
-                    }
-                    m.subs.recorders.push(rec);
-                    if !is_gated {
-                        m.events.post(Event::Record {
-                            state: RecordState::Recording,
-                            reason: None,
+                            reason: Some(format!("open-failed: {e}")),
                             file: Some(file_str),
                             filesize: None,
                         });
                     }
                 }
-                Err(e) => {
-                    m.events.post(Event::Record {
-                        state: RecordState::Finished,
-                        reason: Some(format!("open-failed: {e}")),
-                        file: Some(file_str),
-                        filesize: None,
-                    });
-                }
-            }
             }
             let _ = ack.send(());
         }
         Command::CreateReadStream { id, cfg, sender } => {
-            m.subs.readers.push(super::audio_reader::AudioReader::new(id, cfg, sender));
+            m.subs
+                .readers
+                .push(super::audio_reader::AudioReader::new(id, cfg, sender));
         }
         Command::DestroyReadStream { id } => {
             m.subs.readers.retain(|r| r.id() != id);
@@ -1130,7 +1262,9 @@ async fn apply_forwarded(m: &mut Member, cmd: Command) {
         }
         Command::DestroyWriteStream { id } => {
             if let Some(w) = m.subs.writer.as_ref() {
-                if w.id() == id { m.subs.writer = None; }
+                if w.id() == id {
+                    m.subs.writer = None;
+                }
             }
         }
         Command::RecordFinish { file } => {
@@ -1149,7 +1283,11 @@ async fn apply_forwarded(m: &mut Member, cmd: Command) {
         }
         Command::RecordSetPaused { file, paused } => {
             if let Some(rec) = m.subs.recorders.iter_mut().find(|r| r.file() == file) {
-                if paused { rec.pause(); } else { rec.resume(); }
+                if paused {
+                    rec.pause();
+                } else {
+                    rec.resume();
+                }
             }
         }
         Command::PlayRecord { cfg, ack } => {

--- a/rust/src/channel/player.rs
+++ b/rust/src/channel/player.rs
@@ -72,8 +72,12 @@ impl Player {
         }
     }
 
-    pub fn is_finished(&self) -> bool { self.finished }
-    pub fn interrupts(&self) -> bool { self.spec.interrupt }
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+    pub fn interrupts(&self) -> bool {
+        self.spec.interrupt
+    }
 
     /// Read up to `samples_wanted` 16-bit samples, advancing through files
     /// and loops as needed. Returns fewer samples only when the soup finishes.
@@ -133,17 +137,27 @@ impl Player {
             }
         }
 
-        PlayFrame { samples: out, end_of_file, end_of_soup: end_of_soup || self.finished }
+        PlayFrame {
+            samples: out,
+            end_of_file,
+            end_of_soup: end_of_soup || self.finished,
+        }
     }
 
     async fn open_current(&mut self) -> bool {
         let spec = match self.spec.files.get(self.index) {
             Some(s) => s.clone(),
-            None => { self.finished = true; return false; }
+            None => {
+                self.finished = true;
+                return false;
+            }
         };
         let mut reader = match WavReader::open(&spec.path).await {
             Ok(r) => r,
-            Err(_) => { self.finished = true; return false; }
+            Err(_) => {
+                self.finished = true;
+                return false;
+            }
         };
         if let Some(start) = spec.start_ms {
             let _ = reader.seek_ms(start).await;
@@ -170,7 +184,10 @@ impl Player {
     async fn advance(&mut self) {
         let cur = match self.spec.files.get(self.index).cloned() {
             Some(s) => s,
-            None => { self.finished = true; return; }
+            None => {
+                self.finished = true;
+                return;
+            }
         };
         self.file_loop += 1;
 
@@ -194,8 +211,8 @@ impl Player {
         if self.index >= self.spec.files.len() {
             self.overall_loop += 1;
             let done = match self.spec.overall_loops {
-                None => true,           // play-once
-                Some(0) => false,        // infinite
+                None => true,     // play-once
+                Some(0) => false, // infinite
                 Some(n) => self.overall_loop >= n,
             };
             if done {
@@ -225,7 +242,12 @@ mod tests {
     async fn plays_single_file_once() {
         let p = make_wav("player_single.wav", &vec![1i16; 800]).await;
         let spec = SoundSoupSpec {
-            files: vec![SoundSoupFileSpec { path: p.clone(), start_ms: None, stop_ms: None, max_loops: None }],
+            files: vec![SoundSoupFileSpec {
+                path: p.clone(),
+                start_ms: None,
+                stop_ms: None,
+                max_loops: None,
+            }],
             overall_loops: None,
             interrupt: false,
         };
@@ -243,7 +265,12 @@ mod tests {
     async fn loops_overall_count() {
         let p = make_wav("player_loop.wav", &vec![7i16; 100]).await;
         let spec = SoundSoupSpec {
-            files: vec![SoundSoupFileSpec { path: p.clone(), start_ms: None, stop_ms: None, max_loops: None }],
+            files: vec![SoundSoupFileSpec {
+                path: p.clone(),
+                start_ms: None,
+                stop_ms: None,
+                max_loops: None,
+            }],
             overall_loops: Some(3),
             interrupt: false,
         };
@@ -253,7 +280,9 @@ mod tests {
         loop {
             let frame = pl.read(50).await;
             total += frame.samples.len();
-            if frame.end_of_soup && frame.samples.is_empty() { break; }
+            if frame.end_of_soup && frame.samples.is_empty() {
+                break;
+            }
         }
         assert_eq!(total, 300, "3 loops × 100 samples");
         let _ = std::fs::remove_file(&p);
@@ -265,8 +294,18 @@ mod tests {
         let p2 = make_wav("player_multi2.wav", &vec![22i16; 100]).await;
         let spec = SoundSoupSpec {
             files: vec![
-                SoundSoupFileSpec { path: p1.clone(), start_ms: None, stop_ms: None, max_loops: None },
-                SoundSoupFileSpec { path: p2.clone(), start_ms: None, stop_ms: None, max_loops: None },
+                SoundSoupFileSpec {
+                    path: p1.clone(),
+                    start_ms: None,
+                    stop_ms: None,
+                    max_loops: None,
+                },
+                SoundSoupFileSpec {
+                    path: p2.clone(),
+                    start_ms: None,
+                    stop_ms: None,
+                    max_loops: None,
+                },
             ],
             overall_loops: None,
             interrupt: false,

--- a/rust/src/channel/recorder.rs
+++ b/rust/src/channel/recorder.rs
@@ -107,13 +107,25 @@ impl Recorder {
         })
     }
 
-    pub fn state(&self) -> RecorderState { self.state }
-    pub fn is_finished(&self) -> bool { self.state == RecorderState::Finished }
-    pub fn finish_reason(&self) -> Option<&FinishReason> { self.finish_reason.as_ref() }
-    pub fn file(&self) -> &std::path::Path { &self.cfg.file }
-    pub fn num_channels(&self) -> u16 { self.cfg.num_channels }
+    pub fn state(&self) -> RecorderState {
+        self.state
+    }
+    pub fn is_finished(&self) -> bool {
+        self.state == RecorderState::Finished
+    }
+    pub fn finish_reason(&self) -> Option<&FinishReason> {
+        self.finish_reason.as_ref()
+    }
+    pub fn file(&self) -> &std::path::Path {
+        &self.cfg.file
+    }
+    pub fn num_channels(&self) -> u16 {
+        self.cfg.num_channels
+    }
     /// Total file size in bytes (header + PCM data written so far).
-    pub fn file_size(&self) -> u64 { self.writer.bytes_written() + crate::soundfile::WAV_HEADER_LEN as u64 }
+    pub fn file_size(&self) -> u64 {
+        self.writer.bytes_written() + crate::soundfile::WAV_HEADER_LEN as u64
+    }
 
     pub fn pause(&mut self) {
         if matches!(self.state, RecorderState::Active | RecorderState::Pending) {
@@ -159,7 +171,11 @@ impl Recorder {
     /// to offer (e.g. the `write_raw` code path) and we fall back to
     /// using the frame itself — preserves backward compatibility for
     /// callers that don't plumb the narrowband through.
-    pub async fn write_with_count(&mut self, samples: &[i16], channel_in_count: Option<u64>) -> std::io::Result<bool> {
+    pub async fn write_with_count(
+        &mut self,
+        samples: &[i16],
+        channel_in_count: Option<u64>,
+    ) -> std::io::Result<bool> {
         self.write_frame(samples, samples, channel_in_count).await
     }
 
@@ -173,15 +189,23 @@ impl Recorder {
         power_samples: &[i16],
         channel_in_count: Option<u64>,
     ) -> std::io::Result<bool> {
-        if self.state == RecorderState::Finished { return Ok(false); }
-        if self.state == RecorderState::Paused { return Ok(false); }
+        if self.state == RecorderState::Finished {
+            return Ok(false);
+        }
+        if self.state == RecorderState::Paused {
+            return Ok(false);
+        }
         self.packets_observed += 1;
 
         let warmup_count = channel_in_count.unwrap_or(self.packets_observed);
 
         // Power source: prefer the explicit narrowband; if empty, fall
         // back to the frame itself for compatibility.
-        let power_src: &[i16] = if !power_samples.is_empty() { power_samples } else { samples };
+        let power_src: &[i16] = if !power_samples.is_empty() {
+            power_samples
+        } else {
+            samples
+        };
 
         let pkt_power: i32 = if warmup_count < 100 || power_src.is_empty() {
             0
@@ -224,7 +248,11 @@ impl Recorder {
         // active_ms = elapsed since gate open. Frame length is samples per
         // channel × channels, so divide by (sr * channels) to get seconds.
         let sr = self.cfg.sample_rate as u64 * self.cfg.num_channels as u64;
-        let active_ms = if sr > 0 { self.samples_since_active * 1000 / sr } else { 0 };
+        let active_ms = if sr > 0 {
+            self.samples_since_active * 1000 / sr
+        } else {
+            0
+        };
 
         if let Some(min) = self.cfg.min_duration_ms {
             if active_ms < min {
@@ -261,8 +289,12 @@ impl Recorder {
     ///
     /// Returns the number of samples written.
     pub async fn write_raw(&mut self, samples: &[i16]) -> std::io::Result<usize> {
-        if self.state == RecorderState::Finished { return Ok(0); }
-        if samples.is_empty() { return Ok(0); }
+        if self.state == RecorderState::Finished {
+            return Ok(0);
+        }
+        if samples.is_empty() {
+            return Ok(0);
+        }
         self.writer
             .write_samples(samples)
             .await
@@ -307,7 +339,9 @@ mod tests {
         let mut rec = Recorder::open(c).await.unwrap();
         for _ in 0..10 {
             rec.write(&vec![100i16; 160]).await.unwrap();
-            if rec.is_finished() { break; }
+            if rec.is_finished() {
+                break;
+            }
         }
         assert!(rec.is_finished());
         assert_eq!(rec.finish_reason(), Some(&FinishReason::MaxDurationReached));
@@ -331,21 +365,29 @@ mod tests {
         c.start_above_power = Some(50);
         let path = c.file.clone();
 
-        let loud_ac: Vec<i16> = (0..160).map(|i| if i % 2 == 0 { 5000 } else { -5000 }).collect();
+        let loud_ac: Vec<i16> = (0..160)
+            .map(|i| if i % 2 == 0 { 5000 } else { -5000 })
+            .collect();
 
         let mut rec = Recorder::open(c).await.unwrap();
         // Silent frames during warmup — gate stays closed.
-        for _ in 0..5 { rec.write(&vec![0i16; 160]).await.unwrap(); }
+        for _ in 0..5 {
+            rec.write(&vec![0i16; 160]).await.unwrap();
+        }
         assert_eq!(rec.state(), RecorderState::Pending);
 
         // Pre-warmup loud frames — gate still closed because power is
         // clamped to 0 until packets_observed ≥ 100.
-        for _ in 0..50 { rec.write(&loud_ac).await.unwrap(); }
+        for _ in 0..50 {
+            rec.write(&loud_ac).await.unwrap();
+        }
         assert_eq!(rec.state(), RecorderState::Pending);
 
         // Now cross the warmup and keep feeding — MA filter fills,
         // crosses 50, gate opens.
-        for _ in 0..200 { rec.write(&loud_ac).await.unwrap(); }
+        for _ in 0..200 {
+            rec.write(&loud_ac).await.unwrap();
+        }
         assert_eq!(rec.state(), RecorderState::Active);
 
         rec.close(FinishReason::Completed);
@@ -383,7 +425,9 @@ mod tests {
 
         let mut rec = Recorder::open(c).await.unwrap();
         // Push enough frames to hit max_duration.
-        for _ in 0..5 { rec.write(&vec![100i16; 160]).await.unwrap(); }
+        for _ in 0..5 {
+            rec.write(&vec![100i16; 160]).await.unwrap();
+        }
         assert!(rec.is_finished());
 
         let written = rec.write_raw(&vec![0i16; 100]).await.unwrap();

--- a/rust/src/channel/recv_loop.rs
+++ b/rust/src/channel/recv_loop.rs
@@ -55,13 +55,17 @@ async fn run(cfg: RecvLoopConfig) {
 }
 
 async fn handle_packet(cfg: &RecvLoopConfig, pkt: &[u8], peer: SocketAddr) {
-    if pkt.is_empty() { return; }
+    if pkt.is_empty() {
+        return;
+    }
     let first = pkt[0];
 
     // STUN — respond immediately.
     if stun::is_stun(pkt) {
         let icepwd = cfg.local_icepwd.lock().clone();
-        if icepwd.is_empty() { return; }
+        if icepwd.is_empty() {
+            return;
+        }
         let key = icepwd.as_bytes().to_vec();
         let mut req = pkt.to_vec();
         let mut resp = [0u8; rtp::RTP_MAX_LENGTH];

--- a/rust/src/channel/rtp.rs
+++ b/rust/src/channel/rtp.rs
@@ -55,23 +55,44 @@ pub const RTP_FIXED_HEADER_LEN: usize = 12;
 // ---------- header getters (work on any &[u8]) ----------
 
 #[allow(dead_code)]
-#[inline] pub fn version(pk: &[u8])      -> u8 { (pk[0] & 0xC0) >> 6 }
+#[inline]
+pub fn version(pk: &[u8]) -> u8 {
+    (pk[0] & 0xC0) >> 6
+}
 #[allow(dead_code)]
-#[inline] pub fn padding(pk: &[u8])      -> bool { pk[0] & 0x20 != 0 }
+#[inline]
+pub fn padding(pk: &[u8]) -> bool {
+    pk[0] & 0x20 != 0
+}
 #[allow(dead_code)]
-#[inline] pub fn extension(pk: &[u8])    -> bool { pk[0] & 0x10 != 0 }
-#[inline] pub fn csrc_count(pk: &[u8])   -> u8 { pk[0] & 0x0F }
+#[inline]
+pub fn extension(pk: &[u8]) -> bool {
+    pk[0] & 0x10 != 0
+}
+#[inline]
+pub fn csrc_count(pk: &[u8]) -> u8 {
+    pk[0] & 0x0F
+}
 #[allow(dead_code)]
-#[inline] pub fn marker(pk: &[u8])       -> bool { pk[1] & 0x80 != 0 }
-#[inline] pub fn payload_type(pk: &[u8]) -> u8 { pk[1] & 0x7F }
-#[inline] pub fn sequence_number(pk: &[u8]) -> u16 {
+#[inline]
+pub fn marker(pk: &[u8]) -> bool {
+    pk[1] & 0x80 != 0
+}
+#[inline]
+pub fn payload_type(pk: &[u8]) -> u8 {
+    pk[1] & 0x7F
+}
+#[inline]
+pub fn sequence_number(pk: &[u8]) -> u16 {
     u16::from_be_bytes([pk[2], pk[3]])
 }
-#[inline] pub fn timestamp(pk: &[u8]) -> u32 {
+#[inline]
+pub fn timestamp(pk: &[u8]) -> u32 {
     u32::from_be_bytes([pk[4], pk[5], pk[6], pk[7]])
 }
 #[allow(dead_code)]
-#[inline] pub fn ssrc(pk: &[u8]) -> u32 {
+#[inline]
+pub fn ssrc(pk: &[u8]) -> u32 {
     u32::from_be_bytes([pk[8], pk[9], pk[10], pk[11]])
 }
 
@@ -85,7 +106,11 @@ pub fn header_len(pk: &[u8]) -> usize {
 #[inline]
 #[allow(dead_code)]
 pub fn set_marker(pk: &mut [u8], v: bool) {
-    if v { pk[1] |= 0x80; } else { pk[1] &= 0x7F; }
+    if v {
+        pk[1] |= 0x80;
+    } else {
+        pk[1] &= 0x7F;
+    }
 }
 
 #[inline]
@@ -111,7 +136,9 @@ pub fn set_ssrc(pk: &mut [u8], ssrc: u32) {
 /// Initialise a packet buffer with RTP v2, no flags, given SSRC, zero payload.
 /// Caller sets PT / SN / TS / payload afterwards.
 pub fn init(pk: &mut [u8], ssrc_val: u32) {
-    for b in pk.iter_mut().take(RTP_FIXED_HEADER_LEN) { *b = 0; }
+    for b in pk.iter_mut().take(RTP_FIXED_HEADER_LEN) {
+        *b = 0;
+    }
     pk[0] = 0x80; // v=2, P=0, X=0, CC=0
     set_ssrc(pk, ssrc_val);
 }
@@ -132,7 +159,10 @@ impl RtpPacket {
     pub fn new() -> Self {
         let mut buf = BytesMut::zeroed(RTP_MAX_LENGTH);
         buf[0] = 0x80;
-        Self { buf, len: RTP_FIXED_HEADER_LEN }
+        Self {
+            buf,
+            len: RTP_FIXED_HEADER_LEN,
+        }
     }
 
     /// Wrap a preallocated buffer from a pool. Capacity must be RTP_MAX_LENGTH.
@@ -140,10 +170,17 @@ impl RtpPacket {
     pub fn from_pool(mut buf: BytesMut) -> Self {
         debug_assert_eq!(buf.capacity(), RTP_MAX_LENGTH);
         // Ensure full-length view so direct indexing works.
-        unsafe { buf.set_len(RTP_MAX_LENGTH); }
-        for b in buf.iter_mut().take(RTP_FIXED_HEADER_LEN) { *b = 0; }
+        unsafe {
+            buf.set_len(RTP_MAX_LENGTH);
+        }
+        for b in buf.iter_mut().take(RTP_FIXED_HEADER_LEN) {
+            *b = 0;
+        }
         buf[0] = 0x80;
-        Self { buf, len: RTP_FIXED_HEADER_LEN }
+        Self {
+            buf,
+            len: RTP_FIXED_HEADER_LEN,
+        }
     }
 
     pub fn init(&mut self, ssrc_val: u32) {
@@ -151,20 +188,30 @@ impl RtpPacket {
         self.len = RTP_FIXED_HEADER_LEN;
     }
 
-    pub fn as_slice(&self) -> &[u8] { &self.buf[..self.len] }
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
     #[allow(dead_code)]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] { &mut self.buf[..self.len] }
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.buf[..self.len]
+    }
 
-    pub fn len(&self) -> usize { self.len }
+    pub fn len(&self) -> usize {
+        self.len
+    }
     #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool { self.len == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
     #[allow(dead_code)]
     pub fn set_len(&mut self, len: usize) {
         debug_assert!(len <= self.buf.capacity());
         self.len = len;
     }
 
-    pub fn header_len(&self) -> usize { header_len(&self.buf) }
+    pub fn header_len(&self) -> usize {
+        header_len(&self.buf)
+    }
 
     pub fn payload(&self) -> &[u8] {
         let start = self.header_len();
@@ -197,26 +244,50 @@ impl RtpPacket {
 
     // Header convenience accessors —
     // defer to the free functions so there's one source of truth.
-    pub fn payload_type(&self) -> u8 { payload_type(&self.buf) }
-    pub fn set_payload_type(&mut self, pt: u8) { set_payload_type(&mut self.buf, pt) }
+    pub fn payload_type(&self) -> u8 {
+        payload_type(&self.buf)
+    }
+    pub fn set_payload_type(&mut self, pt: u8) {
+        set_payload_type(&mut self.buf, pt)
+    }
     #[allow(dead_code)]
-    pub fn marker(&self) -> bool { marker(&self.buf) }
+    pub fn marker(&self) -> bool {
+        marker(&self.buf)
+    }
     #[allow(dead_code)]
-    pub fn set_marker(&mut self, v: bool) { set_marker(&mut self.buf, v) }
-    pub fn sequence_number(&self) -> u16 { sequence_number(&self.buf) }
-    pub fn set_sequence_number(&mut self, sn: u16) { set_sequence_number(&mut self.buf, sn) }
-    pub fn timestamp(&self) -> u32 { timestamp(&self.buf) }
-    pub fn set_timestamp(&mut self, ts: u32) { set_timestamp(&mut self.buf, ts) }
+    pub fn set_marker(&mut self, v: bool) {
+        set_marker(&mut self.buf, v)
+    }
+    pub fn sequence_number(&self) -> u16 {
+        sequence_number(&self.buf)
+    }
+    pub fn set_sequence_number(&mut self, sn: u16) {
+        set_sequence_number(&mut self.buf, sn)
+    }
+    pub fn timestamp(&self) -> u32 {
+        timestamp(&self.buf)
+    }
+    pub fn set_timestamp(&mut self, ts: u32) {
+        set_timestamp(&mut self.buf, ts)
+    }
     #[allow(dead_code)]
-    pub fn ssrc(&self) -> u32 { ssrc(&self.buf) }
+    pub fn ssrc(&self) -> u32 {
+        ssrc(&self.buf)
+    }
     #[allow(dead_code)]
-    pub fn set_ssrc(&mut self, s: u32) { set_ssrc(&mut self.buf, s) }
+    pub fn set_ssrc(&mut self, s: u32) {
+        set_ssrc(&mut self.buf, s)
+    }
     #[allow(dead_code)]
-    pub fn csrc_count(&self) -> u8 { csrc_count(&self.buf) }
+    pub fn csrc_count(&self) -> u8 {
+        csrc_count(&self.buf)
+    }
 }
 
 impl Default for RtpPacket {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/channel/state.rs
+++ b/rust/src/channel/state.rs
@@ -68,7 +68,8 @@ pub struct ChannelState {
 
     // DTLS
     pub dtls_inbound_tx: Arc<PLMutex<Option<mpsc::Sender<Vec<u8>>>>>,
-    pub dtls_result_rx: Option<tokio::sync::oneshot::Receiver<Option<super::dtls_session::HandshakeResult>>>,
+    pub dtls_result_rx:
+        Option<tokio::sync::oneshot::Receiver<Option<super::dtls_session::HandshakeResult>>>,
     /// AbortHandle for the spawned DTLS handshake task. Aborted on
     /// channel close so an orphan handshake can't keep polling a dead
     /// transport (which would busy-spin a tokio worker).

--- a/rust/src/channel/tick.rs
+++ b/rust/src/channel/tick.rs
@@ -36,9 +36,9 @@ pub enum TickOutcome {
     Stop,
 }
 
-pub const IDLE_TICK_LIMIT: u64 = 50 * 20;          // 20s — soft idle (no RTP with remote confirmed)
-pub const HARD_TIMEOUT_NO_REMOTE: u64 = 50 * 60 * 60;     // 1hr — remote() never called
-pub const HARD_TIMEOUT_NO_RECV: u64 = 50 * 60 * 60 * 2;   // 2hr — on hold (recv=false)
+pub const IDLE_TICK_LIMIT: u64 = 50 * 20; // 20s — soft idle (no RTP with remote confirmed)
+pub const HARD_TIMEOUT_NO_REMOTE: u64 = 50 * 60 * 60; // 1hr — remote() never called
+pub const HARD_TIMEOUT_NO_RECV: u64 = 50 * 60 * 60 * 2; // 2hr — on hold (recv=false)
 
 // 20 ms at 8 kHz — the canonical narrowband frame length used for
 // recorder/reader frames when the inbound side is silent.
@@ -70,7 +70,9 @@ pub async fn run(state: &mut ChannelState, subs: &mut Subsystems) -> TickOutcome
     let mut inbound_pkt: Option<RtpPacket> = None;
     let mut popped_any = false;
     loop {
-        let Some(pk) = pop_and_decrypt_inbound(state) else { break; };
+        let Some(pk) = pop_and_decrypt_inbound(state) else {
+            break;
+        };
         popped_any = true;
         if pk.payload_type() == state.rfc2833_pt {
             classify_dtmf_inbound(state, subs, &pk).await;
@@ -136,7 +138,9 @@ async fn classify_dtmf_inbound(
     subs: &mut Subsystems,
     pk: &RtpPacket,
 ) -> bool {
-    if pk.payload_type() != state.rfc2833_pt { return false; }
+    if pk.payload_type() != state.rfc2833_pt {
+        return false;
+    }
     let sn = pk.sequence_number();
     let ts = pk.timestamp();
     let payload = &pk.as_slice()[rtp::RTP_FIXED_HEADER_LEN..pk.len()];
@@ -203,7 +207,10 @@ fn tick_writer(state: &mut ChannelState, subs: &mut Subsystems) -> Option<Vec<i1
     };
     // Take-out check: if the writer reports drained+ended, retire it and
     // emit a `play/end` so the JS event sink sees symmetry with `play`.
-    let drained = subs.writer.as_ref().is_some_and(|w| w.is_drained_and_ended());
+    let drained = subs
+        .writer
+        .as_ref()
+        .is_some_and(|w| w.is_drained_and_ended());
     if drained {
         subs.writer = None;
         state.pending_events.push(Event::Play {
@@ -227,22 +234,34 @@ fn decode_inbound(state: &mut ChannelState, pkt: Option<&RtpPacket>) -> Option<V
 /// Smoothed-RMS barge-in check. Only runs when a player is active *and*
 /// we've seen enough inbound packets for the moving average to have
 /// converged (100 packets ≈ 2 s — same constant the recorder uses).
-async fn run_bargein(
-    state: &mut ChannelState,
-    subs: &mut Subsystems,
-    decoded: Option<&[i16]>,
-) {
-    let Some(samples) = decoded else { return; };
-    let Some(bi) = subs.bargein.as_mut() else { return; };
-    if subs.player.is_none() { return; }
-    if state.in_count.load(Ordering::Relaxed) < 100 { return; }
+async fn run_bargein(state: &mut ChannelState, subs: &mut Subsystems, decoded: Option<&[i16]>) {
+    let Some(samples) = decoded else {
+        return;
+    };
+    let Some(bi) = subs.bargein.as_mut() else {
+        return;
+    };
+    if subs.player.is_none() {
+        return;
+    }
+    if state.in_count.load(Ordering::Relaxed) < 100 {
+        return;
+    }
 
     let mut sum_sq: u64 = 0;
-    for s in samples { let v = *s as i64; sum_sq += (v * v) as u64; }
-    let rms = if samples.is_empty() { 0 }
-              else { ((sum_sq / samples.len() as u64) as f64).sqrt() as i32 };
+    for s in samples {
+        let v = *s as i64;
+        sum_sq += (v * v) as u64;
+    }
+    let rms = if samples.is_empty() {
+        0
+    } else {
+        ((sum_sq / samples.len() as u64) as f64).sqrt() as i32
+    };
     let smoothed = bi.power_ma.execute(rms.min(i16::MAX as i32) as i16) as i32;
-    if smoothed <= bi.power_threshold { return; }
+    if smoothed <= bi.power_threshold {
+        return;
+    }
 
     subs.player = None;
     subs.bargein = None;
@@ -258,8 +277,12 @@ async fn run_bargein(
 /// they can be flushed into the recorder on activation — captures the
 /// caller's speech that started before the prompt finished.
 fn accumulate_prebuffer(subs: &mut Subsystems, decoded: Option<&[i16]>) {
-    if subs.player.is_none() || subs.pending_recorder.is_none() { return; }
-    let Some(samples) = decoded else { return; };
+    if subs.player.is_none() || subs.pending_recorder.is_none() {
+        return;
+    }
+    let Some(samples) = decoded else {
+        return;
+    };
 
     let total = subs.prebuffer.len() + samples.len();
     if total > PREBUFFER_CAPACITY_SAMPLES {
@@ -268,7 +291,9 @@ fn accumulate_prebuffer(subs: &mut Subsystems, decoded: Option<&[i16]>) {
             subs.prebuffer.pop_front();
         }
     }
-    for s in samples { subs.prebuffer.push_back(*s); }
+    for s in samples {
+        subs.prebuffer.push_back(*s);
+    }
 }
 
 /// Resolve inbound / outbound sample slices for the tick (same L/R
@@ -311,7 +336,9 @@ async fn feed_recorders_and_readers(
             // inbound (G.722 decode) + the outbound (player/echo/silence)
             // upsampled to 16 kHz so the WAV stays coherent. The recorder's
             // WAV rate is stamped to 16k at open to match.
-            let in_wb = state.codecx.require_wideband_16k()
+            let in_wb = state
+                .codecx
+                .require_wideband_16k()
                 .map(|s| s.to_vec())
                 .unwrap_or_else(|| upsample_2x(in_s));
             let out_wb = upsample_2x(out_s);
@@ -330,11 +357,17 @@ async fn feed_recorders_and_readers(
 /// inbound leg uses the codec's true wideband decode; this only covers the
 /// out side so a stereo native recording stays sample-aligned.
 fn upsample_2x(input: &[i16]) -> Vec<i16> {
-    if input.is_empty() { return Vec::new(); }
+    if input.is_empty() {
+        return Vec::new();
+    }
     let mut out = Vec::with_capacity(input.len() * 2);
     for i in 0..input.len() {
         let cur = input[i] as i32;
-        let next = if i + 1 < input.len() { input[i + 1] as i32 } else { cur };
+        let next = if i + 1 < input.len() {
+            input[i + 1] as i32
+        } else {
+            cur
+        };
         out.push(cur as i16);
         out.push(((cur + next) / 2) as i16);
     }
@@ -405,20 +438,17 @@ fn build_recorder_frame(num_channels: u16, in_s: &[i16], out_s: &[i16], len: usi
         }
         v
     } else {
-        (0..len).map(|j| {
-            let a = in_s.get(j).copied().unwrap_or(0) as i32;
-            let b = out_s.get(j).copied().unwrap_or(0) as i32;
-            (a + b).clamp(i16::MIN as i32, i16::MAX as i32) as i16
-        }).collect()
+        (0..len)
+            .map(|j| {
+                let a = in_s.get(j).copied().unwrap_or(0) as i32;
+                let b = out_s.get(j).copied().unwrap_or(0) as i32;
+                (a + b).clamp(i16::MIN as i32, i16::MAX as i32) as i16
+            })
+            .collect()
     }
 }
 
-fn feed_readers(
-    state: &mut ChannelState,
-    subs: &mut Subsystems,
-    in_s: &[i16],
-    out_s: &[i16],
-) {
+fn feed_readers(state: &mut ChannelState, subs: &mut Subsystems, in_s: &[i16], out_s: &[i16]) {
     for reader in subs.readers.iter_mut() {
         reader.feed(&mut state.codecx, Some(in_s), Some(out_s));
     }
@@ -436,8 +466,12 @@ async fn send_outbound(
     player_frame: Option<&[i16]>,
     inbound_pkt: Option<&RtpPacket>,
 ) {
-    if !state.direction.send { return; }
-    let Some(remote) = state.get_remote_addr() else { return; };
+    if !state.direction.send {
+        return;
+    }
+    let Some(remote) = state.get_remote_addr() else {
+        return;
+    };
 
     if let Some(pkt) = subs.dtmf_send.next_event(state.out_ts) {
         send_dtmf(state, &pkt, remote).await;
@@ -482,7 +516,9 @@ pub(crate) fn poll_dtls_handshake(state: &mut ChannelState) {
         match rx.try_recv() {
             Ok(Some(result)) => {
                 let keys = super::dtls_session::split_keying_material(
-                    &result.keying_material, result.profile, result.is_client,
+                    &result.keying_material,
+                    result.profile,
+                    result.is_client,
                 );
                 let (our_key, our_salt) = if keys.local_is_server {
                     (&keys.server_write_key, &keys.server_write_salt)
@@ -494,12 +530,20 @@ pub(crate) fn poll_dtls_handshake(state: &mut ChannelState) {
                 } else {
                     (&keys.server_write_key, &keys.server_write_salt)
                 };
-                if let Ok(enc) = webrtc_srtp::context::Context::new(
-                    our_key, our_salt, keys.profile, None, None,
-                ) { state.srtp_encrypt = Some(enc); }
+                if let Ok(enc) =
+                    webrtc_srtp::context::Context::new(our_key, our_salt, keys.profile, None, None)
+                {
+                    state.srtp_encrypt = Some(enc);
+                }
                 if let Ok(dec) = webrtc_srtp::context::Context::new(
-                    their_key, their_salt, keys.profile, None, None,
-                ) { state.srtp_decrypt = Some(dec); }
+                    their_key,
+                    their_salt,
+                    keys.profile,
+                    None,
+                    None,
+                ) {
+                    state.srtp_decrypt = Some(dec);
+                }
                 state.srtp_keys = Some(keys);
                 state.dtls_result_rx = None;
                 state.dtls_handshake_abort = None;
@@ -531,7 +575,11 @@ async fn send_rtp(state: &mut ChannelState, pkt: &RtpPacket, remote: SocketAddr)
     }
 }
 
-async fn send_dtmf(state: &mut ChannelState, pkt: &super::dtmf::NextDtmfPacket, remote: SocketAddr) {
+async fn send_dtmf(
+    state: &mut ChannelState,
+    pkt: &super::dtmf::NextDtmfPacket,
+    remote: SocketAddr,
+) {
     let mut out = RtpPacket::new();
     out.init(state.ssrc);
     out.set_payload_type(state.rfc2833_pt);
@@ -553,7 +601,9 @@ async fn send_player_frame(state: &mut ChannelState, samples: &[i16], remote: So
     // persists across ticks for a coherent outbound stream.
     state.codecx.feed_linear_8k(samples);
     let pt = state.remote_pt;
-    let Some(payload) = state.codecx.require_wire_as(pt).map(|b| b.to_vec()) else { return; };
+    let Some(payload) = state.codecx.require_wire_as(pt).map(|b| b.to_vec()) else {
+        return;
+    };
     let mut out = RtpPacket::new();
     out.init(state.ssrc);
     out.set_payload_type(state.remote_pt);
@@ -599,7 +649,10 @@ mod tests {
         let peer_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let peer_addr = peer_sock.local_addr().unwrap();
         let mut state = ChannelState::new(1, rtp_addr, rtp_sock, rtcp_sock, 0xC0FFEE);
-        state.direction = Direction { send: true, recv: true };
+        state.direction = Direction {
+            send: true,
+            recv: true,
+        };
         (state, peer_sock, peer_addr)
     }
 
@@ -612,7 +665,8 @@ mod tests {
         let r = tokio::time::timeout(
             std::time::Duration::from_millis(30),
             peer_sock.recv_from(&mut [0u8; 2000]),
-        ).await;
+        )
+        .await;
         assert!(r.is_err());
     }
 
@@ -628,7 +682,8 @@ mod tests {
         let r = tokio::time::timeout(
             std::time::Duration::from_millis(30),
             peer_sock.recv_from(&mut [0u8; 2000]),
-        ).await;
+        )
+        .await;
         assert!(r.is_err());
     }
 
@@ -657,39 +712,181 @@ mod tests {
         // audio SNs interleaved between burst body / end packets are
         // synthesised below so the buffer ordering matches the wire.
         let bursts: &[(u32, u8, &[(u16, bool)])] = &[
-            (36160,  9, &[(226,false),(228,false),(230,false),(232,false),
-                          (234,false),(236,false),(238,false),
-                          (239,true),(241,true),(242,true)]),
-            (113280, 1, &[(718,false),(720,false),(722,false),(724,false),
-                          (726,false),(728,false),(730,false),
-                          (731,true),(733,true),(734,true)]),
-            (116640, 9, &[(749,false),(751,false),(753,false),(755,false),
-                          (757,false),(759,false),(761,false),
-                          (762,true),(764,true),(765,true)]),
-            (120000, 9, &[(780,false),(782,false),(784,false),(786,false),
-                          (788,false),(790,false),(792,false),
-                          (793,true),(795,true),(796,true)]),
-            (123200, 3, &[(810,false),(812,false),(814,false),(816,false),
-                          (818,false),(820,false),(822,false),
-                          (823,true),(825,true),(826,true)]),
-            (179840, 3, &[(1174,false),(1176,false),(1178,false),(1180,false),
-                          (1182,false),(1184,false),(1186,false),
-                          (1187,true),(1189,true),(1190,true)]),
-            (232640, 1, &[(1514,false),(1516,false),(1518,false),(1520,false),
-                          (1522,false),(1524,false),(1526,false),
-                          (1527,true),(1529,true),(1530,true)]),
-            (235200, 1, &[(1540,false),(1542,false),(1544,false),(1546,false),
-                          (1548,false),(1550,false),
-                          (1551,true),(1553,true),(1554,true)]),
-            (261440, 1, &[(1713,false),(1715,false),(1717,false),(1719,false),
-                          (1721,false),(1723,false),(1725,false),
-                          (1726,true),(1728,true),(1729,true)]),
-            (324800, 1, &[(2119,false),(2121,false),(2123,false),(2125,false),
-                          (2127,false),(2129,false),(2131,false),
-                          (2132,true),(2134,true),(2135,true)]),
-            (328480, 2, &[(2152,false),(2154,false),(2156,false),(2158,false),
-                          (2160,false),(2162,false),(2164,false),
-                          (2165,true),(2167,true),(2168,true)]),
+            (
+                36160,
+                9,
+                &[
+                    (226, false),
+                    (228, false),
+                    (230, false),
+                    (232, false),
+                    (234, false),
+                    (236, false),
+                    (238, false),
+                    (239, true),
+                    (241, true),
+                    (242, true),
+                ],
+            ),
+            (
+                113280,
+                1,
+                &[
+                    (718, false),
+                    (720, false),
+                    (722, false),
+                    (724, false),
+                    (726, false),
+                    (728, false),
+                    (730, false),
+                    (731, true),
+                    (733, true),
+                    (734, true),
+                ],
+            ),
+            (
+                116640,
+                9,
+                &[
+                    (749, false),
+                    (751, false),
+                    (753, false),
+                    (755, false),
+                    (757, false),
+                    (759, false),
+                    (761, false),
+                    (762, true),
+                    (764, true),
+                    (765, true),
+                ],
+            ),
+            (
+                120000,
+                9,
+                &[
+                    (780, false),
+                    (782, false),
+                    (784, false),
+                    (786, false),
+                    (788, false),
+                    (790, false),
+                    (792, false),
+                    (793, true),
+                    (795, true),
+                    (796, true),
+                ],
+            ),
+            (
+                123200,
+                3,
+                &[
+                    (810, false),
+                    (812, false),
+                    (814, false),
+                    (816, false),
+                    (818, false),
+                    (820, false),
+                    (822, false),
+                    (823, true),
+                    (825, true),
+                    (826, true),
+                ],
+            ),
+            (
+                179840,
+                3,
+                &[
+                    (1174, false),
+                    (1176, false),
+                    (1178, false),
+                    (1180, false),
+                    (1182, false),
+                    (1184, false),
+                    (1186, false),
+                    (1187, true),
+                    (1189, true),
+                    (1190, true),
+                ],
+            ),
+            (
+                232640,
+                1,
+                &[
+                    (1514, false),
+                    (1516, false),
+                    (1518, false),
+                    (1520, false),
+                    (1522, false),
+                    (1524, false),
+                    (1526, false),
+                    (1527, true),
+                    (1529, true),
+                    (1530, true),
+                ],
+            ),
+            (
+                235200,
+                1,
+                &[
+                    (1540, false),
+                    (1542, false),
+                    (1544, false),
+                    (1546, false),
+                    (1548, false),
+                    (1550, false),
+                    (1551, true),
+                    (1553, true),
+                    (1554, true),
+                ],
+            ),
+            (
+                261440,
+                1,
+                &[
+                    (1713, false),
+                    (1715, false),
+                    (1717, false),
+                    (1719, false),
+                    (1721, false),
+                    (1723, false),
+                    (1725, false),
+                    (1726, true),
+                    (1728, true),
+                    (1729, true),
+                ],
+            ),
+            (
+                324800,
+                1,
+                &[
+                    (2119, false),
+                    (2121, false),
+                    (2123, false),
+                    (2125, false),
+                    (2127, false),
+                    (2129, false),
+                    (2131, false),
+                    (2132, true),
+                    (2134, true),
+                    (2135, true),
+                ],
+            ),
+            (
+                328480,
+                2,
+                &[
+                    (2152, false),
+                    (2154, false),
+                    (2156, false),
+                    (2158, false),
+                    (2160, false),
+                    (2162, false),
+                    (2164, false),
+                    (2165, true),
+                    (2167, true),
+                    (2168, true),
+                ],
+            ),
         ];
         let dtmf_pt = state.rfc2833_pt;
 
@@ -711,8 +908,12 @@ mod tests {
         for (ts, ev, packets) in bursts {
             for (sn, end) in *packets {
                 all_dtmf_sns.insert(*sn, (*ts, *ev, *end));
-                if *sn < min_sn { min_sn = *sn; }
-                if *sn > max_sn { max_sn = *sn; }
+                if *sn < min_sn {
+                    min_sn = *sn;
+                }
+                if *sn > max_sn {
+                    max_sn = *sn;
+                }
             }
         }
 
@@ -737,7 +938,7 @@ mod tests {
             // immediately preceded by DTMF at sn-1), wire delta is 10 ms.
             // Otherwise it's 20 ms (steady audio cadence).
             let is_dtmf = all_dtmf_sns.contains_key(&sn);
-            let prev_dtmf = sn > min_sn && all_dtmf_sns.contains_key(&(sn-1));
+            let prev_dtmf = sn > min_sn && all_dtmf_sns.contains_key(&(sn - 1));
             let delta_ms = if is_dtmf && prev_was_audio {
                 // DTMF arrives 10 ms after the paired audio
                 10
@@ -789,8 +990,9 @@ mod tests {
 
         assert_eq!(
             digits,
-            vec!['9','1','9','9','3','3','1','1','1','1','2'],
-            "expected full IVR digit sequence; got {:?}", digits
+            vec!['9', '1', '9', '9', '3', '3', '1', '1', '1', '1', '2'],
+            "expected full IVR digit sequence; got {:?}",
+            digits
         );
     }
 
@@ -803,7 +1005,7 @@ mod tests {
         assert_eq!(out[1], 150); // (100+200)/2
         assert_eq!(out[2], 200);
         assert_eq!(out[3], 250); // (200+300)/2
-        // last sample duplicates (no next to interpolate toward)
+                                 // last sample duplicates (no next to interpolate toward)
         assert_eq!(out[7], 400);
         assert!(upsample_2x(&[]).is_empty());
     }

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -63,7 +63,11 @@ const fn compute_alaw_to_linear(alaw: u8) -> i16 {
     } else {
         i += 8;
     }
-    if a & 0x80 != 0 { i as i16 } else { -(i as i16) }
+    if a & 0x80 != 0 {
+        i as i16
+    } else {
+        -(i as i16)
+    }
 }
 
 const fn compute_linear_to_ulaw(linear: i32) -> u8 {
@@ -84,7 +88,11 @@ const fn compute_linear_to_ulaw(linear: i32) -> u8 {
 const fn compute_ulaw_to_linear(ulaw: u8) -> i16 {
     let u = !ulaw;
     let t = (((u as i32 & 0x0F) << 3) + 0x84) << ((u as i32 & 0x70) >> 4);
-    if u & 0x80 != 0 { (0x84 - t) as i16 } else { (t - 0x84) as i16 }
+    if u & 0x80 != 0 {
+        (0x84 - t) as i16
+    } else {
+        (t - 0x84) as i16
+    }
 }
 
 // `table[i]` stores the compressed byte for `i as i16` (i.e. the sample
@@ -231,7 +239,9 @@ pub struct CodecBundle {
 }
 
 impl Default for CodecBundle {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CodecBundle {
@@ -255,8 +265,12 @@ impl CodecBundle {
         }
     }
 
-    pub fn set_local_ilbc_pt(&mut self, pt: u8) { self.ilbc_pts[0] = pt; }
-    pub fn set_peer_ilbc_pt(&mut self, pt: u8) { self.ilbc_pts[1] = pt; }
+    pub fn set_local_ilbc_pt(&mut self, pt: u8) {
+        self.ilbc_pts[0] = pt;
+    }
+    pub fn set_peer_ilbc_pt(&mut self, pt: u8) {
+        self.ilbc_pts[1] = pt;
+    }
 
     fn is_ilbc_pt(&self, pt: u8) -> bool {
         pt == 97 || pt == self.ilbc_pts[0] || pt == self.ilbc_pts[1]
@@ -319,7 +333,11 @@ impl CodecBundle {
     /// The channel's native PCM sample rate inferred from the wire codec:
     /// 16 kHz for G.722, 8 kHz otherwise (incl. before a codec is known).
     pub fn native_samplerate(&self) -> u32 {
-        if self.is_wideband() { 16000 } else { 8000 }
+        if self.is_wideband() {
+            16000
+        } else {
+            8000
+        }
     }
 
     // ---- Fast path: raw wire bytes if the PT matches -----------------------
@@ -336,13 +354,19 @@ impl CodecBundle {
     /// audio in that case).
     #[allow(dead_code)]
     pub fn raw_wire_if_pt(&self, pt: u8) -> Option<&[u8]> {
-        if self.wire_pt == 255 || self.wire_bytes.is_empty() { return None; }
+        if self.wire_pt == 255 || self.wire_bytes.is_empty() {
+            return None;
+        }
         let match_ok = match pt {
             0 | 8 | 9 => pt == self.wire_pt,
             _ if self.is_ilbc_pt(pt) => self.is_ilbc_pt(self.wire_pt),
             _ => false,
         };
-        if match_ok { Some(&self.wire_bytes) } else { None }
+        if match_ok {
+            Some(&self.wire_bytes)
+        } else {
+            None
+        }
     }
 
     // ---- Lazy accessors ----------------------------------------------------
@@ -357,9 +381,9 @@ impl CodecBundle {
         // Path 1: decode directly from wire PT.
         if !self.wire_bytes.is_empty() {
             if self.is_ilbc_pt(self.wire_pt) {
-                let dec = self.ilbc_decoder.get_or_insert_with(|| {
-                    crate::ilbc::Decoder::new().expect("ilbc decoder init")
-                });
+                let dec = self
+                    .ilbc_decoder
+                    .get_or_insert_with(|| crate::ilbc::Decoder::new().expect("ilbc decoder init"));
                 if let Some(v) = dec.decode(&self.wire_bytes) {
                     self.narrowband_8k = Some(v);
                     return self.narrowband_8k.as_deref();
@@ -414,9 +438,9 @@ impl CodecBundle {
 
         // Path 1: G.722 wire → wideband (decode only, no resample).
         if self.wire_pt == 9 && !self.wire_bytes.is_empty() {
-            let dec = self.g722_decoder.get_or_insert_with(|| {
-                crate::g722::Decoder::new().expect("g722 decoder init")
-            });
+            let dec = self
+                .g722_decoder
+                .get_or_insert_with(|| crate::g722::Decoder::new().expect("g722 decoder init"));
             let decoded = dec.decode(&self.wire_bytes);
             if !decoded.is_empty() {
                 self.wideband_16k = Some(decoded.to_vec());
@@ -460,9 +484,18 @@ impl CodecBundle {
         if let Some(wire) = src.raw_wire_if_pt(pt) {
             let owned = wire.to_vec();
             match pt {
-                0 => { self.pcmu_out = Some(owned); return self.pcmu_out.as_deref(); }
-                8 => { self.pcma_out = Some(owned); return self.pcma_out.as_deref(); }
-                9 => { self.g722_out = Some(owned); return self.g722_out.as_deref(); }
+                0 => {
+                    self.pcmu_out = Some(owned);
+                    return self.pcmu_out.as_deref();
+                }
+                8 => {
+                    self.pcma_out = Some(owned);
+                    return self.pcma_out.as_deref();
+                }
+                9 => {
+                    self.g722_out = Some(owned);
+                    return self.g722_out.as_deref();
+                }
                 p if self.is_ilbc_pt(p) => {
                     self.ilbc_out = Some(owned);
                     return self.ilbc_out.as_deref();
@@ -477,11 +510,13 @@ impl CodecBundle {
         if pt == 9 {
             let out: Vec<u8> = {
                 let wb = src.require_wideband_16k()?;
-                let enc = self.g722_encoder.get_or_insert_with(|| {
-                    crate::g722::Encoder::new().expect("g722 encoder init")
-                });
+                let enc = self
+                    .g722_encoder
+                    .get_or_insert_with(|| crate::g722::Encoder::new().expect("g722 encoder init"));
                 let wire = enc.encode(wb);
-                if wire.is_empty() { return None; }
+                if wire.is_empty() {
+                    return None;
+                }
                 wire.to_vec()
             };
             self.g722_out = Some(out);
@@ -492,9 +527,9 @@ impl CodecBundle {
         if self.is_ilbc_pt(pt) {
             let out: Option<Vec<u8>> = {
                 let nb = src.require_narrowband_8k()?;
-                let enc = self.ilbc_encoder.get_or_insert_with(|| {
-                    crate::ilbc::Encoder::new().expect("ilbc encoder init")
-                });
+                let enc = self
+                    .ilbc_encoder
+                    .get_or_insert_with(|| crate::ilbc::Encoder::new().expect("ilbc encoder init"));
                 enc.encode_20ms(nb)
             };
             self.ilbc_out = out;
@@ -522,19 +557,23 @@ impl CodecBundle {
     /// with the same `pt` returns the previous result.
     pub fn require_wire_as(&mut self, pt: u8) -> Option<&[u8]> {
         if self.is_ilbc_pt(pt) {
-            if self.ilbc_out.is_some() { return self.ilbc_out.as_deref(); }
+            if self.ilbc_out.is_some() {
+                return self.ilbc_out.as_deref();
+            }
             self.require_narrowband_8k()?;
             let nb = self.narrowband_8k.as_ref().unwrap();
-            let enc = self.ilbc_encoder.get_or_insert_with(|| {
-                crate::ilbc::Encoder::new().expect("ilbc encoder init")
-            });
+            let enc = self
+                .ilbc_encoder
+                .get_or_insert_with(|| crate::ilbc::Encoder::new().expect("ilbc encoder init"));
             let out = enc.encode_20ms(nb)?;
             self.ilbc_out = Some(out);
             return self.ilbc_out.as_deref();
         }
         match pt {
             0 => {
-                if self.pcmu_out.is_some() { return self.pcmu_out.as_deref(); }
+                if self.pcmu_out.is_some() {
+                    return self.pcmu_out.as_deref();
+                }
                 self.require_narrowband_8k()?;
                 let nb = self.narrowband_8k.as_ref().unwrap();
                 let out: Vec<u8> = nb.iter().map(|&s| linear_to_ulaw(s as i32)).collect();
@@ -542,7 +581,9 @@ impl CodecBundle {
                 self.pcmu_out.as_deref()
             }
             8 => {
-                if self.pcma_out.is_some() { return self.pcma_out.as_deref(); }
+                if self.pcma_out.is_some() {
+                    return self.pcma_out.as_deref();
+                }
                 self.require_narrowband_8k()?;
                 let nb = self.narrowband_8k.as_ref().unwrap();
                 let out: Vec<u8> = nb.iter().map(|&s| linear_to_alaw(s as i32)).collect();
@@ -550,14 +591,18 @@ impl CodecBundle {
                 self.pcma_out.as_deref()
             }
             9 => {
-                if self.g722_out.is_some() { return self.g722_out.as_deref(); }
+                if self.g722_out.is_some() {
+                    return self.g722_out.as_deref();
+                }
                 self.require_wideband_16k()?;
                 let wb_samples = self.wideband_16k.as_ref().unwrap();
-                let enc = self.g722_encoder.get_or_insert_with(|| {
-                    crate::g722::Encoder::new().expect("g722 encoder init")
-                });
+                let enc = self
+                    .g722_encoder
+                    .get_or_insert_with(|| crate::g722::Encoder::new().expect("g722 encoder init"));
                 let wire = enc.encode(wb_samples);
-                if wire.is_empty() { return None; }
+                if wire.is_empty() {
+                    return None;
+                }
                 self.g722_out = Some(wire.to_vec());
                 self.g722_out.as_deref()
             }
@@ -565,7 +610,6 @@ impl CodecBundle {
         }
     }
 }
-
 
 /// 16 kHz → 8 kHz downsample: for each pair of input samples, run both
 /// through the shared LP filter (to update its state) and keep only the
@@ -615,7 +659,9 @@ pub fn ulaw_to_linear(ulaw: u8) -> i16 {
 
 fn clamp_linear_index(val: i32) -> Option<i16> {
     let shifted = val + 32768;
-    if !(0..=65535).contains(&shifted) { return None; }
+    if !(0..=65535).contains(&shifted) {
+        return None;
+    }
     Some((shifted - 32768) as i16)
 }
 
@@ -676,7 +722,10 @@ mod tests {
             let a = linear_to_alaw(s);
             let back = alaw_to_linear(a) as i32;
             let err = (back - s).abs();
-            assert!(err <= 1024, "roundtrip err {err} too large for {s} -> {a:02X} -> {back}");
+            assert!(
+                err <= 1024,
+                "roundtrip err {err} too large for {s} -> {a:02X} -> {back}"
+            );
         }
     }
 
@@ -690,7 +739,10 @@ mod tests {
             let a = linear_to_alaw(s);
             let back = alaw_to_linear(a) as i32;
             let err = (back - s).abs();
-            assert!(err <= 16, "near-zero roundtrip err {err} for {s} -> {a:02X} -> {back}");
+            assert!(
+                err <= 16,
+                "near-zero roundtrip err {err} for {s} -> {a:02X} -> {back}"
+            );
         }
     }
 
@@ -700,7 +752,10 @@ mod tests {
             let u = linear_to_ulaw(s);
             let back = ulaw_to_linear(u) as i32;
             let err = (back - s).abs();
-            assert!(err <= 1024, "roundtrip err {err} too large for {s} -> {u:02X} -> {back}");
+            assert!(
+                err <= 1024,
+                "roundtrip err {err} too large for {s} -> {u:02X} -> {back}"
+            );
         }
     }
 

--- a/rust/src/dtls.rs
+++ b/rust/src/dtls.rs
@@ -20,7 +20,9 @@ use webrtc_dtls::crypto::Certificate;
 fn hex_colon(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 3);
     for (i, b) in bytes.iter().enumerate() {
-        if i > 0 { s.push(':'); }
+        if i > 0 {
+            s.push(':');
+        }
         s.push_str(&format!("{:02X}", b));
     }
     s
@@ -35,7 +37,9 @@ fn init_cert() -> Certificate {
 }
 
 fn compute_fingerprint(cert: &Certificate) -> String {
-    let der = cert.certificate.first()
+    let der = cert
+        .certificate
+        .first()
         .expect("cert has at least one DER entry")
         .as_ref();
     hex_colon(&Sha256::digest(der))

--- a/rust/src/firfilter.rs
+++ b/rust/src/firfilter.rs
@@ -12,9 +12,8 @@ pub const LOWPASS_LEN: usize = 17;
 // Coefficients lifted verbatim from the C++ version (Kaiser-Bessel, 16 kHz
 // sampling, 3.4 kHz cutoff — for 16k→8k downsampling anti-alias).
 const LP_COEFFS: [f32; LOWPASS_LEN] = [
-    -0.002102, 0.000519, 0.014189, 0.010317, -0.037919, -0.060378, 0.063665,
-    0.299972, 0.425000, 0.299972, 0.063665, -0.060378, -0.037919, 0.010317,
-    0.014189, 0.000519, -0.002102,
+    -0.002102, 0.000519, 0.014189, 0.010317, -0.037919, -0.060378, 0.063665, 0.299972, 0.425000,
+    0.299972, 0.063665, -0.060378, -0.037919, 0.010317, 0.014189, 0.000519, -0.002102,
 ];
 
 pub struct Lowpass3_4k16k {
@@ -23,11 +22,18 @@ pub struct Lowpass3_4k16k {
 }
 
 impl Default for Lowpass3_4k16k {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Lowpass3_4k16k {
-    pub fn new() -> Self { Self { history: [0.0; LOWPASS_LEN], round: 0 } }
+    pub fn new() -> Self {
+        Self {
+            history: [0.0; LOWPASS_LEN],
+            round: 0,
+        }
+    }
 
     #[allow(dead_code)]
     pub fn reset(&mut self) {
@@ -67,12 +73,19 @@ pub struct MaFilter {
 }
 
 impl Default for MaFilter {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MaFilter {
     pub fn new() -> Self {
-        Self { history: [0.0; MA_LENGTH], round: 0, l: MA_LENGTH, rtotal: 0 }
+        Self {
+            history: [0.0; MA_LENGTH],
+            round: 0,
+            l: MA_LENGTH,
+            rtotal: 0,
+        }
     }
 
     pub fn reset(&mut self, packets: usize) {
@@ -91,22 +104,36 @@ impl MaFilter {
     }
 
     #[allow(dead_code)]
-    pub fn get(&self) -> i32 { self.rtotal / self.l as i32 }
+    pub fn get(&self) -> i32 {
+        self.rtotal / self.l as i32
+    }
     #[allow(dead_code)]
-    pub fn length(&self) -> usize { self.l }
+    pub fn length(&self) -> usize {
+        self.l
+    }
 }
 
 // DC blocker. y[n] = x[n] - x[n-1] + 0.995 * y[n-1]
-pub struct DcFilter { xm: i16, ym: i16 }
+pub struct DcFilter {
+    xm: i16,
+    ym: i16,
+}
 
 impl Default for DcFilter {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DcFilter {
-    pub fn new() -> Self { Self { xm: 0, ym: 0 } }
+    pub fn new() -> Self {
+        Self { xm: 0, ym: 0 }
+    }
     #[allow(dead_code)]
-    pub fn reset(&mut self) { self.xm = 0; self.ym = 0; }
+    pub fn reset(&mut self) {
+        self.xm = 0;
+        self.ym = 0;
+    }
 
     #[inline]
     pub fn execute(&mut self, x: i16) -> i16 {
@@ -142,7 +169,9 @@ mod tests {
     #[test]
     fn lowpass_zero_input_zero_output() {
         let mut f = Lowpass3_4k16k::new();
-        for _ in 0..100 { assert_eq!(f.execute(0), 0); }
+        for _ in 0..100 {
+            assert_eq!(f.execute(0), 0);
+        }
     }
 
     #[test]
@@ -150,7 +179,9 @@ mod tests {
         // Sum of coefficients is ~1.0 → DC input passes through near-unity.
         let mut f = Lowpass3_4k16k::new();
         let mut last = 0i16;
-        for _ in 0..100 { last = f.execute(1000); }
+        for _ in 0..100 {
+            last = f.execute(1000);
+        }
         assert!((last as i32 - 1000).abs() < 50, "DC gain off: {last}");
     }
 
@@ -158,11 +189,17 @@ mod tests {
     fn ma_reaches_target_for_constant_input() {
         let mut m = MaFilter::new();
         m.reset(MA_LENGTH);
-        for _ in 0..MA_LENGTH { m.execute(1); }
+        for _ in 0..MA_LENGTH {
+            m.execute(1);
+        }
         assert_eq!(m.get(), 1);
-        for _ in 0..(MA_LENGTH / 2) { m.execute(100); }
+        for _ in 0..(MA_LENGTH / 2) {
+            m.execute(100);
+        }
         assert_eq!(m.get(), 50);
-        for _ in 0..(MA_LENGTH / 2) { m.execute(100); }
+        for _ in 0..(MA_LENGTH / 2) {
+            m.execute(100);
+        }
         assert_eq!(m.get(), 100);
     }
 
@@ -170,7 +207,9 @@ mod tests {
     fn dc_filter_removes_dc() {
         let mut f = DcFilter::new();
         let mut last = 0i16;
-        for _ in 0..2000 { last = f.execute(5000); }
+        for _ in 0..2000 {
+            last = f.execute(5000);
+        }
         assert!(last.abs() < 50, "DC not removed: {last}");
     }
 }

--- a/rust/src/g722.rs
+++ b/rust/src/g722.rs
@@ -36,11 +36,19 @@ pub struct G722DecodeState {
 }
 
 extern "C" {
-    fn g722_encode_init(s: *mut G722EncodeState, rate: c_int, options: c_int) -> *mut G722EncodeState;
+    fn g722_encode_init(
+        s: *mut G722EncodeState,
+        rate: c_int,
+        options: c_int,
+    ) -> *mut G722EncodeState;
     fn g722_encode_free(s: *mut G722EncodeState) -> c_int;
     fn g722_encode(s: *mut G722EncodeState, out: *mut u8, amp: *const i16, len: c_int) -> c_int;
 
-    fn g722_decode_init(s: *mut G722DecodeState, rate: c_int, options: c_int) -> *mut G722DecodeState;
+    fn g722_decode_init(
+        s: *mut G722DecodeState,
+        rate: c_int,
+        options: c_int,
+    ) -> *mut G722DecodeState;
     fn g722_decode_free(s: *mut G722DecodeState) -> c_int;
     fn g722_decode(s: *mut G722DecodeState, out: *mut i16, bits: *const u8, len: c_int) -> c_int;
 }
@@ -71,17 +79,14 @@ impl Encoder {
         // True 16 kHz G.722 — matches C++ projectrtpcodecx.cpp:368 which
         // uses `G722_PACKED` only. The `G722_SAMPLE_RATE_8000` flag is a
         // test-vector mode that produces non-standard wire output.
-        let state = unsafe {
-            g722_encode_init(
-                std::ptr::null_mut(),
-                G722_RATE_64000,
-                G722_PACKED,
-            )
-        };
+        let state = unsafe { g722_encode_init(std::ptr::null_mut(), G722_RATE_64000, G722_PACKED) };
         if state.is_null() {
             return None;
         }
-        Some(Self { state, out_buf: vec![0u8; G722_FRAME_BYTES] })
+        Some(Self {
+            state,
+            out_buf: vec![0u8; G722_FRAME_BYTES],
+        })
     }
 
     /// Encode 16 kHz linear PCM to G.722. Input must be exactly 320
@@ -110,7 +115,9 @@ impl Encoder {
 impl Drop for Encoder {
     fn drop(&mut self) {
         if !self.state.is_null() {
-            unsafe { g722_encode_free(self.state); }
+            unsafe {
+                g722_encode_free(self.state);
+            }
             self.state = std::ptr::null_mut();
         }
     }
@@ -127,17 +134,14 @@ unsafe impl Send for Decoder {}
 impl Decoder {
     pub fn new() -> Option<Self> {
         // True 16 kHz G.722 — see Encoder::new for rationale.
-        let state = unsafe {
-            g722_decode_init(
-                std::ptr::null_mut(),
-                G722_RATE_64000,
-                G722_PACKED,
-            )
-        };
+        let state = unsafe { g722_decode_init(std::ptr::null_mut(), G722_RATE_64000, G722_PACKED) };
         if state.is_null() {
             return None;
         }
-        Some(Self { state, out_buf: vec![0i16; G722_FRAME_SAMPLES] })
+        Some(Self {
+            state,
+            out_buf: vec![0i16; G722_FRAME_SAMPLES],
+        })
     }
 
     /// Decode G.722 to 16 kHz linear PCM. Input must be exactly 160
@@ -166,7 +170,9 @@ impl Decoder {
 impl Drop for Decoder {
     fn drop(&mut self) {
         if !self.state.is_null() {
-            unsafe { g722_decode_free(self.state); }
+            unsafe {
+                g722_decode_free(self.state);
+            }
             self.state = std::ptr::null_mut();
         }
     }

--- a/rust/src/ilbc.rs
+++ b/rust/src/ilbc.rs
@@ -79,7 +79,9 @@ impl Encoder {
         }
         let init = unsafe { WebRtcIlbcfix_EncoderInit(inst, FRAME_LEN_MS) };
         if init != 0 {
-            unsafe { WebRtcIlbcfix_EncoderFree(inst); }
+            unsafe {
+                WebRtcIlbcfix_EncoderFree(inst);
+            }
             return None;
         }
         Some(Self { inst })
@@ -106,7 +108,9 @@ impl Encoder {
 impl Drop for Encoder {
     fn drop(&mut self) {
         if !self.inst.is_null() {
-            unsafe { WebRtcIlbcfix_EncoderFree(self.inst); }
+            unsafe {
+                WebRtcIlbcfix_EncoderFree(self.inst);
+            }
             self.inst = std::ptr::null_mut();
         }
     }
@@ -128,7 +132,9 @@ impl Decoder {
         }
         let init = unsafe { WebRtcIlbcfix_DecoderInit(inst, FRAME_LEN_MS) };
         if init != 0 {
-            unsafe { WebRtcIlbcfix_DecoderFree(inst); }
+            unsafe {
+                WebRtcIlbcfix_DecoderFree(inst);
+            }
             return None;
         }
         Some(Self { inst })
@@ -163,7 +169,9 @@ impl Decoder {
 impl Drop for Decoder {
     fn drop(&mut self) {
         if !self.inst.is_null() {
-            unsafe { WebRtcIlbcfix_DecoderFree(self.inst); }
+            unsafe {
+                WebRtcIlbcfix_DecoderFree(self.inst);
+            }
             self.inst = std::ptr::null_mut();
         }
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,11 +17,11 @@ use napi_derive::napi;
 mod channel;
 mod codec;
 mod dtls;
+mod firfilter;
 mod g722;
 mod ilbc;
 mod portpool;
 mod rtpbuffer;
-mod firfilter;
 mod soundfile;
 mod stun;
 mod tone;
@@ -29,7 +29,7 @@ mod tone;
 /// Default port range if none is supplied. Matches the C++ defaults in
 /// projectrtpnodemain.cpp.
 const DEFAULT_PORT_START: u16 = 10_000;
-const DEFAULT_PORT_END:   u16 = 20_000;
+const DEFAULT_PORT_END: u16 = 20_000;
 
 #[cfg_attr(not(test), napi)]
 pub fn run(params: Option<Object>) -> napi::Result<()> {
@@ -38,8 +38,14 @@ pub fn run(params: Option<Object>) -> napi::Result<()> {
         .as_ref()
         .and_then(|p| p.get_named_property::<Object>("ports").ok())
         .map(|ports| {
-            let s = ports.get_named_property::<u32>("start").ok().unwrap_or(DEFAULT_PORT_START as u32) as u16;
-            let e = ports.get_named_property::<u32>("end").ok().unwrap_or(DEFAULT_PORT_END as u32) as u16;
+            let s = ports
+                .get_named_property::<u32>("start")
+                .ok()
+                .unwrap_or(DEFAULT_PORT_START as u32) as u16;
+            let e = ports
+                .get_named_property::<u32>("end")
+                .ok()
+                .unwrap_or(DEFAULT_PORT_END as u32) as u16;
             (s, e)
         })
         .unwrap_or((DEFAULT_PORT_START, DEFAULT_PORT_END));
@@ -55,10 +61,14 @@ pub async fn shutdown() -> napi::Result<()> {
     // Timeout after 5 seconds to avoid hanging forever.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
-        if channel::facade::active_channel_count() == 0 { break; }
+        if channel::facade::active_channel_count() == 0 {
+            break;
+        }
         if std::time::Instant::now() >= deadline {
-            eprintln!("projectrtp shutdown: {} channels still active after timeout",
-                      channel::facade::active_channel_count());
+            eprintln!(
+                "projectrtp shutdown: {} channels still active after timeout",
+                channel::facade::active_channel_count()
+            );
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -110,7 +120,11 @@ pub fn stats() -> napi::Result<Stats> {
     // the C++ `channelscreated` counter but split so dashboards can
     // chart open-rate vs close-rate independently.
     let available = portpool::available_count();
-    let available = if portpool::is_initialized() { available } else { 10_000 };
+    let available = if portpool::is_initialized() {
+        available
+    } else {
+        10_000
+    };
     Ok(Stats {
         channel: ChannelCounts {
             current: channel::facade::active_channel_count() as u32,

--- a/rust/src/portpool.rs
+++ b/rust/src/portpool.rs
@@ -28,14 +28,22 @@ static POOL: Mutex<Option<PortPool>> = Mutex::new(None);
 /// pool is replaced wholesale).
 pub fn init(start: u16, end: u16) {
     let mut p = start;
-    if p % 2 != 0 { p = p.saturating_add(1); }
+    if p % 2 != 0 {
+        p = p.saturating_add(1);
+    }
     let mut q = VecDeque::new();
     while p + 1 < end {
         q.push_back(p);
-        p = match p.checked_add(2) { Some(v) => v, None => break };
+        p = match p.checked_add(2) {
+            Some(v) => v,
+            None => break,
+        };
     }
     let total = q.len() as u32;
-    *POOL.lock().unwrap() = Some(PortPool { available: q, total });
+    *POOL.lock().unwrap() = Some(PortPool {
+        available: q,
+        total,
+    });
 }
 
 pub fn is_initialized() -> bool {
@@ -45,16 +53,25 @@ pub fn is_initialized() -> bool {
 /// Take the next even port. Returns None when the pool is uninitialized or
 /// exhausted — the caller distinguishes the two cases via `is_initialized`.
 pub fn acquire() -> Option<u16> {
-    POOL.lock().unwrap().as_mut().and_then(|p| p.available.pop_front())
+    POOL.lock()
+        .unwrap()
+        .as_mut()
+        .and_then(|p| p.available.pop_front())
 }
 
 /// Return a port to the pool — no-op if the pool is uninitialized.
 pub fn release(port: u16) {
-    if let Some(p) = POOL.lock().unwrap().as_mut() { p.available.push_back(port); }
+    if let Some(p) = POOL.lock().unwrap().as_mut() {
+        p.available.push_back(port);
+    }
 }
 
 pub fn available_count() -> u32 {
-    POOL.lock().unwrap().as_ref().map(|p| p.available.len() as u32).unwrap_or(0)
+    POOL.lock()
+        .unwrap()
+        .as_ref()
+        .map(|p| p.available.len() as u32)
+        .unwrap_or(0)
 }
 
 #[allow(dead_code)]
@@ -70,13 +87,19 @@ pub struct PortReservation {
 }
 
 impl PortReservation {
-    pub fn new(port: u16) -> Self { Self { port } }
+    pub fn new(port: u16) -> Self {
+        Self { port }
+    }
     #[allow(dead_code)]
-    pub fn port(&self) -> u16 { self.port }
+    pub fn port(&self) -> u16 {
+        self.port
+    }
 }
 
 impl Drop for PortReservation {
-    fn drop(&mut self) { release(self.port); }
+    fn drop(&mut self) {
+        release(self.port);
+    }
 }
 
 #[cfg(test)]
@@ -87,7 +110,9 @@ mod tests {
     fn init_populates_only_even_ports() {
         init(10_000, 10_010);
         let mut acquired = Vec::new();
-        while let Some(p) = acquire() { acquired.push(p); }
+        while let Some(p) = acquire() {
+            acquired.push(p);
+        }
         assert_eq!(acquired, vec![10_000, 10_002, 10_004, 10_006, 10_008]);
     }
 

--- a/rust/src/rtpbuffer.rs
+++ b/rust/src/rtpbuffer.rs
@@ -7,7 +7,9 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::channel::jitter::{JitterBuffer, DEFAULT_BUFFER_PACKET_COUNT, DEFAULT_BUFFER_WATER_LEVEL};
+use crate::channel::jitter::{
+    JitterBuffer, DEFAULT_BUFFER_PACKET_COUNT, DEFAULT_BUFFER_WATER_LEVEL,
+};
 use crate::channel::rtp::RtpPacket;
 
 #[cfg_attr(not(test), napi(object))]
@@ -66,7 +68,10 @@ impl RtpJitterBuffer {
 
     #[napi]
     pub fn poppeeked(&mut self) -> Either<Buffer, Undefined> {
-        let copy = self.inner.peek().map(|p| Buffer::from(p.as_slice().to_vec()));
+        let copy = self
+            .inner
+            .peek()
+            .map(|p| Buffer::from(p.as_slice().to_vec()));
         self.inner.discard_peeked();
         match copy {
             Some(b) => Either::A(b),
@@ -84,8 +89,12 @@ impl RtpJitterBuffer {
 pub fn create(opts: Option<BufferOptions>) -> Result<RtpJitterBuffer> {
     let (size, water) = match opts {
         Some(o) => (
-            o.size.map(|n| n as usize).unwrap_or(DEFAULT_BUFFER_PACKET_COUNT),
-            o.waterlevel.map(|n| n as usize).unwrap_or(DEFAULT_BUFFER_WATER_LEVEL),
+            o.size
+                .map(|n| n as usize)
+                .unwrap_or(DEFAULT_BUFFER_PACKET_COUNT),
+            o.waterlevel
+                .map(|n| n as usize)
+                .unwrap_or(DEFAULT_BUFFER_WATER_LEVEL),
         ),
         None => (DEFAULT_BUFFER_PACKET_COUNT, DEFAULT_BUFFER_WATER_LEVEL),
     };

--- a/rust/src/soundfile.rs
+++ b/rust/src/soundfile.rs
@@ -49,10 +49,18 @@ pub struct WavHeader {
 }
 
 fn parse_header(h: &[u8; WAV_HEADER_LEN]) -> Result<WavHeader> {
-    if &h[0..4] != b"RIFF" { return Err(Error::from_reason("Bad RIFF")); }
-    if &h[8..12] != b"WAVE" { return Err(Error::from_reason("Bad WAVE")); }
-    if &h[12..16] != b"fmt " { return Err(Error::from_reason("Bad fmt")); }
-    if &h[36..40] != b"data" { return Err(Error::from_reason("Bad data")); }
+    if &h[0..4] != b"RIFF" {
+        return Err(Error::from_reason("Bad RIFF"));
+    }
+    if &h[8..12] != b"WAVE" {
+        return Err(Error::from_reason("Bad WAVE"));
+    }
+    if &h[12..16] != b"fmt " {
+        return Err(Error::from_reason("Bad fmt"));
+    }
+    if &h[36..40] != b"data" {
+        return Err(Error::from_reason("Bad data"));
+    }
 
     Ok(WavHeader {
         chunksize: u32::from_le_bytes(h[4..8].try_into().unwrap()),
@@ -174,17 +182,29 @@ impl WavReader {
         }
         let data_start = WAV_HEADER_LEN as u64;
         let data_end = data_start + header.subchunksize as u64;
-        Ok(Self { file, header, data_start, data_end, url })
+        Ok(Self {
+            file,
+            header,
+            data_start,
+            data_end,
+            url,
+        })
     }
 
-    pub fn header(&self) -> &WavHeader { &self.header }
+    pub fn header(&self) -> &WavHeader {
+        &self.header
+    }
     #[allow(dead_code)]
-    pub fn url(&self) -> &Path { &self.url }
+    pub fn url(&self) -> &Path {
+        &self.url
+    }
 
     /// Read up to `samples` int16 samples starting from the current position.
     /// Returns a vec that may be shorter than `samples` if EOF is hit.
     pub async fn read_samples(&mut self, samples: usize) -> Result<Vec<i16>> {
-        let max_bytes = samples.checked_mul(2).ok_or_else(|| Error::from_reason("overflow"))?;
+        let max_bytes = samples
+            .checked_mul(2)
+            .ok_or_else(|| Error::from_reason("overflow"))?;
         let pos = self.file.stream_position().await.map_err(io_err)?;
         let remaining = self.data_end.saturating_sub(pos) as usize;
         let to_read = max_bytes.min(remaining);
@@ -204,7 +224,9 @@ impl WavReader {
         let mut offset = bytes_per_ms * ms;
         // Align to sample boundary.
         let align = self.header.sample_alignment as u64;
-        if align > 0 { offset -= offset % align; }
+        if align > 0 {
+            offset -= offset % align;
+        }
         let abs = self.data_start + offset.min(self.data_end - self.data_start);
         self.file.seek(SeekFrom::Start(abs)).await.map_err(io_err)?;
         Ok(())
@@ -215,14 +237,18 @@ impl WavReader {
         let pos = self.file.stream_position().await.map_err(io_err)?;
         let data_pos = pos.saturating_sub(self.data_start);
         let bytes_per_ms = (self.header.byte_rate as u64) / 1000;
-        if bytes_per_ms == 0 { return Ok(0); }
+        if bytes_per_ms == 0 {
+            return Ok(0);
+        }
         Ok(data_pos / bytes_per_ms)
     }
 
     #[allow(dead_code)]
     pub fn duration_ms(&self) -> u64 {
         let bytes_per_ms = (self.header.byte_rate as u64) / 1000;
-        if bytes_per_ms == 0 { return 0; }
+        if bytes_per_ms == 0 {
+            return 0;
+        }
         (self.header.subchunksize as u64) / bytes_per_ms
     }
 
@@ -267,7 +293,10 @@ impl WavWriter {
             .open(&url)
             .await
             .map_err(|e| Error::from_reason(format!("create {url:?}: {e}")))?;
-        afile.write_all(&build_header(&header)).await.map_err(io_err)?;
+        afile
+            .write_all(&build_header(&header))
+            .await
+            .map_err(io_err)?;
         afile.flush().await.map_err(io_err)?;
         let file = afile.into_std().await;
         Ok(Self {
@@ -280,17 +309,30 @@ impl WavWriter {
     }
 
     #[allow(dead_code)]
-    pub fn header(&self) -> &WavHeader { &self.header }
+    pub fn header(&self) -> &WavHeader {
+        &self.header
+    }
     #[allow(dead_code)]
-    pub fn url(&self) -> &Path { &self.url }
+    pub fn url(&self) -> &Path {
+        &self.url
+    }
     #[allow(dead_code)]
-    pub fn bytes_written(&self) -> u64 { self.bytes_written }
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
 
     pub async fn write_samples(&mut self, samples: &[i16]) -> Result<()> {
-        if self.closed { return Err(Error::from_reason("writer closed")); }
+        if self.closed {
+            return Err(Error::from_reason("writer closed"));
+        }
         let mut buf = Vec::with_capacity(samples.len() * 2);
-        for s in samples { buf.extend_from_slice(&s.to_le_bytes()); }
-        let _file = self.file.as_mut().ok_or_else(|| Error::from_reason("no file"))?;
+        for s in samples {
+            buf.extend_from_slice(&s.to_le_bytes());
+        }
+        let _file = self
+            .file
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("no file"))?;
         // std::fs::File writes are synchronous — do them via spawn_blocking so
         // we don't stall the tokio worker during long writes on slow disks.
         let to_write = buf;
@@ -313,10 +355,17 @@ impl WavWriter {
 
     #[allow(dead_code)]
     pub fn write_samples_sync(&mut self, samples: &[i16]) -> Result<()> {
-        if self.closed { return Err(Error::from_reason("writer closed")); }
+        if self.closed {
+            return Err(Error::from_reason("writer closed"));
+        }
         use std::io::Write;
-        let file = self.file.as_mut().ok_or_else(|| Error::from_reason("no file"))?;
-        for s in samples { file.write_all(&s.to_le_bytes()).map_err(io_err)?; }
+        let file = self
+            .file
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("no file"))?;
+        for s in samples {
+            file.write_all(&s.to_le_bytes()).map_err(io_err)?;
+        }
         self.bytes_written += (samples.len() as u64) * 2;
         Ok(())
     }
@@ -324,7 +373,9 @@ impl WavWriter {
     /// Finalize the header explicitly. Idempotent; Drop will call this if
     /// not already done.
     pub fn close(&mut self) -> Result<()> {
-        if self.closed { return Ok(()); }
+        if self.closed {
+            return Ok(());
+        }
         self.closed = true;
         let mut file = match self.file.take() {
             Some(f) => f,
@@ -349,7 +400,9 @@ impl Drop for WavWriter {
     }
 }
 
-fn io_err(e: std::io::Error) -> Error { Error::from_reason(e.to_string()) }
+fn io_err(e: std::io::Error) -> Error {
+    Error::from_reason(e.to_string())
+}
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/stun.rs
+++ b/rust/src/stun.rs
@@ -52,15 +52,29 @@ fn message_class(pk: &[u8]) -> u8 {
     ((c0 >> 4) as u8) | ((c1 >> 8) as u8)
 }
 
-fn message_length(pk: &[u8]) -> u16 { read_u16(pk, 2) }
-fn set_message_length(pk: &mut [u8], v: u16) { write_u16(pk, 2, v); }
-fn magic_cookie(pk: &[u8]) -> u32 { read_u32(pk, 4) }
+fn message_length(pk: &[u8]) -> u16 {
+    read_u16(pk, 2)
+}
+fn set_message_length(pk: &mut [u8], v: u16) {
+    write_u16(pk, 2, v);
+}
+fn magic_cookie(pk: &[u8]) -> u32 {
+    read_u32(pk, 4)
+}
 
 pub fn is_stun(pk: &[u8]) -> bool {
-    if pk.len() < STUN_HEADER_LEN { return false; }
-    if (pk[0] & 0b1100_0000) != 0 { return false; }
-    if (pk.len() - STUN_HEADER_LEN) != message_length(pk) as usize { return false; }
-    if magic_cookie(pk) != MAGIC_COOKIE { return false; }
+    if pk.len() < STUN_HEADER_LEN {
+        return false;
+    }
+    if (pk[0] & 0b1100_0000) != 0 {
+        return false;
+    }
+    if (pk.len() - STUN_HEADER_LEN) != message_length(pk) as usize {
+        return false;
+    }
+    if magic_cookie(pk) != MAGIC_COOKIE {
+        return false;
+    }
     true
 }
 
@@ -93,22 +107,34 @@ fn verify_fingerprint(pk: &[u8], attr_off: usize) -> bool {
 }
 
 fn walk_attributes(pk: &mut [u8], remote_key: &[u8]) -> bool {
-    if remote_key.is_empty() { return false; }
+    if remote_key.is_empty() {
+        return false;
+    }
     let total = STUN_HEADER_LEN + message_length(pk) as usize;
-    if total > pk.len() { return false; }
+    if total > pk.len() {
+        return false;
+    }
 
     let mut off = STUN_HEADER_LEN;
     while off + 4 <= total {
         let attr_type = read_u16(pk, off);
         let attr_len = read_u16(pk, off + 2) as usize;
-        if off + 4 + attr_len > total { return false; }
+        if off + 4 + attr_len > total {
+            return false;
+        }
 
         match attr_type {
-            0x0008 => { // MESSAGE-INTEGRITY
-                if !verify_integrity(pk, off, remote_key) { return false; }
+            0x0008 => {
+                // MESSAGE-INTEGRITY
+                if !verify_integrity(pk, off, remote_key) {
+                    return false;
+                }
             }
-            0x8028 => { // FINGERPRINT
-                if !verify_fingerprint(pk, off) { return false; }
+            0x8028 => {
+                // FINGERPRINT
+                if !verify_fingerprint(pk, off) {
+                    return false;
+                }
             }
             // USERNAME / PRIORITY / USE-CANDIDATE / ICE-CONTROLLING /
             // GOOG-NETWORK-INFO — accept without validation.
@@ -185,8 +211,12 @@ fn create_binding_response(
     endpoint: SocketAddr,
     local_key: &[u8],
 ) -> usize {
-    if response.len() < STUN_HEADER_LEN || local_key.is_empty() { return 0; }
-    for b in response.iter_mut().take(STUN_HEADER_LEN) { *b = 0; }
+    if response.len() < STUN_HEADER_LEN || local_key.is_empty() {
+        return 0;
+    }
+    for b in response.iter_mut().take(STUN_HEADER_LEN) {
+        *b = 0;
+    }
 
     write_u16(response, 0, 0x0101); // Binding Response
     write_u32(response, 4, MAGIC_COOKIE);
@@ -209,12 +239,18 @@ pub fn handle(
     local_key: &[u8],
     remote_key: &[u8],
 ) -> usize {
-    if !is_stun(pk) { return 0; }
-    if message_method(pk) != 0x01 { return 0; }
+    if !is_stun(pk) {
+        return 0;
+    }
+    if message_method(pk) != 0x01 {
+        return 0;
+    }
 
     if message_class(pk) == 0 {
         // Binding Request
-        if !walk_attributes(pk, remote_key) { return 0; }
+        if !walk_attributes(pk, remote_key) {
+            return 0;
+        }
         create_binding_response(pk, response, endpoint, local_key)
     } else {
         // Binding Success response from peer — validate but don't reply.
@@ -234,7 +270,9 @@ mod tests {
         write_u16(&mut pk, 0, 0x0001); // Binding Request
         write_u32(&mut pk, 4, MAGIC_COOKIE);
         // transaction id = [1..13) fixed
-        for i in 0..12 { pk[8 + i] = (i as u8) + 1; }
+        for i in 0..12 {
+            pk[8 + i] = (i as u8) + 1;
+        }
 
         // MESSAGE-INTEGRITY attribute at offset 20
         let mi_off = pk.len();

--- a/rust/src/tone.rs
+++ b/rust/src/tone.rs
@@ -59,9 +59,13 @@ fn gentone(
     end_amp: f64,
     sample_rate: u32,
 ) {
-    if start_freq == 0.0 && end_freq == 0.0 { return; }
+    if start_freq == 0.0 && end_freq == 0.0 {
+        return;
+    }
     let n = out.len();
-    if n == 0 { return; }
+    if n == 0 {
+        return;
+    }
     let amp_per_sample = (end_amp - start_amp) / n as f64;
     let freq_per_sample = (end_freq - start_freq) / n as f64;
     let mut ampatpos = start_amp;
@@ -74,7 +78,8 @@ fn gentone(
     for (i, slot) in out.iter_mut().enumerate() {
         let v = (angle * i as f64).sin() * i16::MAX as f64 * ampatpos;
         // Saturating add to prevent wrap on overlapping `+` tones.
-        let sum = (*slot as i32).saturating_add(v as i32)
+        let sum = (*slot as i32)
+            .saturating_add(v as i32)
             .clamp(i16::MIN as i32, i16::MAX as i32);
         *slot = sum as i16;
         ampatpos += amp_per_sample;
@@ -88,7 +93,10 @@ fn gentone(
 }
 
 #[derive(Debug)]
-struct AmpSpec { start: f64, end: f64 }
+struct AmpSpec {
+    start: f64,
+    end: f64,
+}
 
 fn parse_amp(spec: &str) -> AmpSpec {
     // spec is the part after `*`, may be `a` or `a~b`.
@@ -102,7 +110,13 @@ fn gen_block(out: &mut [i16], freq_spec: &str) {
     // Split off amplitude (`*amp[~amp2]`) first.
     let (freq_part, amp) = match freq_spec.split_once('*') {
         Some((f, a)) => (f, parse_amp(a)),
-        None => (freq_spec, AmpSpec { start: 1.0, end: 1.0 }),
+        None => (
+            freq_spec,
+            AmpSpec {
+                start: 1.0,
+                end: 1.0,
+            },
+        ),
     };
 
     // Detect operator: `+` sum, `~` sweep. `x` modulation not implemented (matches C++).
@@ -158,7 +172,9 @@ pub fn generate(tone: &str, filename: &Path) -> Result<()> {
     for (i, freq_spec) in frequencies.iter().enumerate() {
         let ms = cadences[i % cadences.len()];
         let block_len = (ms * SAMPLE_RATE / 1000) as usize;
-        if pos + block_len > samples.len() { break; }
+        if pos + block_len > samples.len() {
+            break;
+        }
         gen_block(&mut samples[pos..pos + block_len], freq_spec);
         pos += block_len;
     }
@@ -201,7 +217,9 @@ fn append_to_wav(filename: &Path, new_data: &[u8]) -> Result<()> {
     let (format, sr, existing_data) = read_wav_header(&hdr)
         .ok_or_else(|| Error::from_reason("existing file is not a valid WAV"))?;
     if format != WAVE_FORMAT_PCM || sr != SAMPLE_RATE {
-        return Err(Error::from_reason("existing WAV format/samplerate mismatch"));
+        return Err(Error::from_reason(
+            "existing WAV format/samplerate mismatch",
+        ));
     }
 
     let new_total = existing_data + new_data.len() as u32;
@@ -213,7 +231,9 @@ fn append_to_wav(filename: &Path, new_data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn wrap_io(e: std::io::Error) -> Error { Error::from_reason(e.to_string()) }
+fn wrap_io(e: std::io::Error) -> Error {
+    Error::from_reason(e.to_string())
+}
 
 #[cfg_attr(not(test), napi(namespace = "tone", js_name = "generate"))]
 pub fn js_generate(tone: String, filename: String) -> Result<bool> {
@@ -268,7 +288,10 @@ mod tests {
         let pcm = &data[WAV_HEADER_LEN..];
         // Second half should be silent.
         let half = pcm.len() / 2;
-        assert!(pcm[half..].iter().all(|b| *b == 0), "silence block not zero");
+        assert!(
+            pcm[half..].iter().all(|b| *b == 0),
+            "silence block not zero"
+        );
 
         let _ = fs::remove_file(&tmp);
     }


### PR DESCRIPTION
## Problem

The **Rust CI** workflow fails at the rustfmt step:

```
cargo fmt --all -- --check
Diff in rust/src/tone.rs:201 ...
Process completed with exit code 1
```

The `rust/` tree was committed without ever running rustfmt, so the drift spans the whole crate (27 files), not just `tone.rs`.

## Fix

Run `cargo fmt --all` and commit the result. Changes are purely formatting — multi-line enum variants, import ordering, block wrapping — with **no semantic effect**. Verified with `cargo fmt --all -- --check` (now passes) using stable rustfmt 1.8.0, default config (no `rustfmt.toml`), edition 2021 — matching the `@stable` toolchain CI uses.

This is independent of the Docker build / libilbc submodule failure, which is handled in #158. It is large but mechanical; reviewing per-commit or with whitespace hidden is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)