### PR TITLE
Fix CI: Build (npm + lockfile) and Rust CI (rustfmt + clippy on stable 1.96)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,10 @@ CMD [ "./node_modules/mocha/bin/_mocha", "test/interface/*.js", "test/unit/*.js"
                                                                                                                                                                                               
 FROM alpine:3.22 AS app
 WORKDIR /app
-RUN apk add --no-cache nodejs ca-certificates libstdc++ spandsp3
+RUN apk add --no-cache nodejs npm ca-certificates libstdc++ spandsp3
 COPY --from=rust-builder /usr/local/lib/libilbc.so* /usr/lib/
 COPY --from=rust-builder /src/rust/target/release/libprojectrtp.so /app/build/Release/projectrtp.node
-COPY index.js package.json /app/                                                                                                                                                            
+COPY index.js package.json package-lock.json /app/                                                                                                                                                            
 COPY lib/ /app/lib/                                       
 COPY examples/ /app/examples/                                                                                                                                                               
 RUN npm ci --omit=dev --ignore-scripts                    

--- a/rust/src/channel/actor.rs
+++ b/rust/src/channel/actor.rs
@@ -75,7 +75,7 @@ pub enum Event {
         file: Option<String>,
         filesize: Option<u64>,
     },
-    TelephoneEvent {
+    Telephone {
         digit: char,
     },
     Mix {
@@ -292,6 +292,12 @@ pub(super) async fn activate_pending_recorder(
 
 /// Top-level actor ownership. `Local` runs the per-channel ticker; `Mixed`
 /// delegates ticks + most commands to the mix actor.
+//
+// `Local` is the common (non-mixed) case and carries the full `Subsystems`
+// inline; `Mixed` is small. Boxing `Local` to equalize the variants would
+// add a heap indirection on the hot per-channel path and ripple through the
+// mix-migration `Member` type, so we keep it inline deliberately.
+#[allow(clippy::large_enum_variant)]
 enum Mode {
     Local {
         state: Box<ChannelState>,
@@ -1056,11 +1062,13 @@ mod tests {
         let file_str = path.to_string_lossy().into_owned();
 
         let mut events: Vec<Event> = Vec::new();
-        let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder {
-            cfg,
-            file_str: file_str.clone(),
-        });
+        let mut subs = Subsystems {
+            pending_recorder: Some(PendingRecorder {
+                cfg,
+                file_str: file_str.clone(),
+            }),
+            ..Default::default()
+        };
         subs.prebuffer.extend(vec![500i16; 800]);
 
         let activated = activate_pending_recorder(&mut subs, &mut events).await;
@@ -1094,11 +1102,13 @@ mod tests {
         let file_str = path.to_string_lossy().into_owned();
 
         let mut events: Vec<Event> = Vec::new();
-        let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder {
-            cfg,
-            file_str: file_str.clone(),
-        });
+        let mut subs = Subsystems {
+            pending_recorder: Some(PendingRecorder {
+                cfg,
+                file_str: file_str.clone(),
+            }),
+            ..Default::default()
+        };
         subs.prebuffer.extend(vec![100i16; 400]);
 
         assert!(activate_pending_recorder(&mut subs, &mut events).await);
@@ -1119,11 +1129,13 @@ mod tests {
         let file_str = path.to_string_lossy().into_owned();
 
         let mut events: Vec<Event> = Vec::new();
-        let mut subs = Subsystems::default();
-        subs.pending_recorder = Some(PendingRecorder {
-            cfg,
-            file_str: file_str.clone(),
-        });
+        let mut subs = Subsystems {
+            pending_recorder: Some(PendingRecorder {
+                cfg,
+                file_str: file_str.clone(),
+            }),
+            ..Default::default()
+        };
 
         assert!(activate_pending_recorder(&mut subs, &mut events).await);
         // Gated recorders don't emit Recording until the gate opens; the

--- a/rust/src/channel/dtmf.rs
+++ b/rust/src/channel/dtmf.rs
@@ -495,7 +495,8 @@ mod tests {
         // in the pcap so the second "1" must be reported via end-bit
         // clearing, not the timestamp fallback.
         let mut r = DtmfReceiver::new();
-        let bursts: &[(u32, u8, &[(u16, bool)])] = &[
+        type Burst<'a> = (u32, u8, &'a [(u16, bool)]);
+        let bursts: &[Burst<'_>] = &[
             (
                 36160,
                 9,

--- a/rust/src/channel/facade.rs
+++ b/rust/src/channel/facade.rs
@@ -142,7 +142,7 @@ fn event_to_payload(ev: Event) -> EventPayload {
                 filesize,
             }
         }
-        Event::TelephoneEvent { digit } => EventPayload {
+        Event::Telephone { digit } => EventPayload {
             action: "telephone-event",
             reason: None,
             event: Some(digit.to_string()),
@@ -1175,7 +1175,7 @@ pub fn open_channel(env: Env, params: Object, callback: JsFunction) -> Result<Ch
     // Apply params.direction (if the caller supplied one) before anything
     // else so the channel observes the right send/recv flags on its first
     // tick. Skip the send if the user didn't override the defaults.
-    if initial_direction.send != true || initial_direction.recv != true {
+    if !initial_direction.send || !initial_direction.recv {
         let _ = handle
             .cmd
             .try_send(super::commands::Command::Direction(initial_direction));

--- a/rust/src/channel/mixer.rs
+++ b/rust/src/channel/mixer.rs
@@ -375,9 +375,7 @@ impl Member {
                 activate_recorder = true;
             }
         }
-        self.state
-            .pending_events
-            .push(Event::TelephoneEvent { digit });
+        self.state.pending_events.push(Event::Telephone { digit });
         if activate_recorder {
             let _ = activate_pending_recorder(&mut self.subs, &mut self.state.pending_events).await;
         }

--- a/rust/src/channel/player.rs
+++ b/rust/src/channel/player.rs
@@ -87,11 +87,9 @@ impl Player {
         let mut end_of_soup = false;
 
         while out.len() < samples_wanted && !self.finished {
-            if self.reader.is_none() {
-                if !self.open_current().await {
-                    end_of_soup = true;
-                    break;
-                }
+            if self.reader.is_none() && !self.open_current().await {
+                end_of_soup = true;
+                break;
             }
 
             // For a 16 kHz (or higher) source we read `ratio` source samples
@@ -109,10 +107,13 @@ impl Player {
                 }
                 need_src = need_src.min(rem as usize);
             }
-            let read = match self.reader.as_mut().unwrap().read_samples(need_src).await {
-                Ok(v) => v,
-                Err(_) => Vec::new(),
-            };
+            let read = self
+                .reader
+                .as_mut()
+                .unwrap()
+                .read_samples(need_src)
+                .await
+                .unwrap_or_default();
 
             if read.is_empty() {
                 // EOF for this file.
@@ -263,7 +264,7 @@ mod tests {
 
     #[tokio::test]
     async fn loops_overall_count() {
-        let p = make_wav("player_loop.wav", &vec![7i16; 100]).await;
+        let p = make_wav("player_loop.wav", &[7i16; 100]).await;
         let spec = SoundSoupSpec {
             files: vec![SoundSoupFileSpec {
                 path: p.clone(),
@@ -290,8 +291,8 @@ mod tests {
 
     #[tokio::test]
     async fn advances_through_multiple_files() {
-        let p1 = make_wav("player_multi1.wav", &vec![11i16; 100]).await;
-        let p2 = make_wav("player_multi2.wav", &vec![22i16; 100]).await;
+        let p1 = make_wav("player_multi1.wav", &[11i16; 100]).await;
+        let p2 = make_wav("player_multi2.wav", &[22i16; 100]).await;
         let spec = SoundSoupSpec {
             files: vec![
                 SoundSoupFileSpec {

--- a/rust/src/channel/recorder.rs
+++ b/rust/src/channel/recorder.rs
@@ -82,7 +82,7 @@ impl Recorder {
     pub async fn open(cfg: RecorderConfig) -> std::io::Result<Self> {
         let writer = WavWriter::create(&cfg.file, cfg.num_channels, cfg.sample_rate)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         let mut power_ma = MaFilter::new();
         if let Some(n) = cfg.power_averaging_packets {
             power_ma.reset(n as usize);
@@ -240,7 +240,7 @@ impl Recorder {
         self.writer
             .write_samples(samples)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         let n = samples.len() as u64;
         self.samples_written += n;
         self.samples_since_active += n;
@@ -248,11 +248,9 @@ impl Recorder {
         // active_ms = elapsed since gate open. Frame length is samples per
         // channel × channels, so divide by (sr * channels) to get seconds.
         let sr = self.cfg.sample_rate as u64 * self.cfg.num_channels as u64;
-        let active_ms = if sr > 0 {
-            self.samples_since_active * 1000 / sr
-        } else {
-            0
-        };
+        let active_ms = (self.samples_since_active * 1000)
+            .checked_div(sr)
+            .unwrap_or(0);
 
         if let Some(min) = self.cfg.min_duration_ms {
             if active_ms < min {
@@ -298,7 +296,7 @@ impl Recorder {
         self.writer
             .write_samples(samples)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         self.samples_written += samples.len() as u64;
         Ok(samples.len())
     }
@@ -430,7 +428,7 @@ mod tests {
         }
         assert!(rec.is_finished());
 
-        let written = rec.write_raw(&vec![0i16; 100]).await.unwrap();
+        let written = rec.write_raw(&[0i16; 100]).await.unwrap();
         assert_eq!(written, 0);
 
         rec.close(FinishReason::Completed);

--- a/rust/src/channel/tick.rs
+++ b/rust/src/channel/tick.rs
@@ -157,7 +157,7 @@ async fn classify_dtmf_inbound(
                 activate_recorder = true;
             }
         }
-        state.pending_events.push(Event::TelephoneEvent { digit });
+        state.pending_events.push(Event::Telephone { digit });
         if activate_recorder {
             let _ = activate_pending_recorder(subs, &mut state.pending_events).await;
         }
@@ -711,7 +711,8 @@ mod tests {
         // Each burst: (ts, event_code, [(dtmf_sn, end_bit), ...]). The
         // audio SNs interleaved between burst body / end packets are
         // synthesised below so the buffer ordering matches the wire.
-        let bursts: &[(u32, u8, &[(u16, bool)])] = &[
+        type Burst<'a> = (u32, u8, &'a [(u16, bool)]);
+        let bursts: &[Burst<'_>] = &[
             (
                 36160,
                 9,
@@ -971,7 +972,7 @@ mod tests {
             while wire_ms >= tick_target_ms {
                 run(&mut state, &mut subs).await;
                 for ev in state.pending_events.drain(..) {
-                    if let crate::channel::actor::Event::TelephoneEvent { digit } = ev {
+                    if let crate::channel::actor::Event::Telephone { digit } = ev {
                         digits.push(digit);
                     }
                 }
@@ -982,7 +983,7 @@ mod tests {
         for _ in 0..40 {
             run(&mut state, &mut subs).await;
             for ev in state.pending_events.drain(..) {
-                if let crate::channel::actor::Event::TelephoneEvent { digit } = ev {
+                if let crate::channel::actor::Event::Telephone { digit } = ev {
                     digits.push(digit);
                 }
             }

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -56,7 +56,7 @@ const fn compute_linear_to_alaw(linear: i32) -> u8 {
 
 const fn compute_alaw_to_linear(alaw: u8) -> i16 {
     let a = alaw ^ 0x55;
-    let mut i = ((a as i32 & 0x0F) << 4) as i32;
+    let mut i = (a as i32 & 0x0F) << 4;
     let seg = (a as i32 & 0x70) >> 4;
     if seg != 0 {
         i = (i + 0x108) << (seg - 1);
@@ -281,7 +281,9 @@ impl CodecBundle {
 
     /// Record the negotiated (SDP) RTP payload type. Drives the wideband
     /// classification before any packet has been decoded.
-    pub fn set_negotiated_pt(&mut self, pt: u8) { self.negotiated_pt = pt; }
+    pub fn set_negotiated_pt(&mut self, pt: u8) {
+        self.negotiated_pt = pt;
+    }
 
     fn is_ilbc_pt(&self, pt: u8) -> bool {
         pt == 97 || pt == self.ilbc_pts[0] || pt == self.ilbc_pts[1]
@@ -433,8 +435,7 @@ impl CodecBundle {
         }
 
         // Path 2: downsample from cached wideband.
-        if self.wideband_16k.is_some() {
-            let wb = self.wideband_16k.as_ref().unwrap();
+        if let Some(wb) = self.wideband_16k.as_ref() {
             let mut nb = Vec::with_capacity(wb.len() / 2);
             g722_down_into(wb, &mut self.g722_down_filter, &mut nb);
             self.narrowband_8k = Some(nb);

--- a/rust/src/firfilter.rs
+++ b/rust/src/firfilter.rs
@@ -148,7 +148,7 @@ impl DcFilter {
 #[cfg_attr(not(test), napi(namespace = "rtpfilter", js_name = "filterlowfir"))]
 pub fn js_filter_lowfir(mut buf: Buffer) -> Result<bool> {
     let bytes: &mut [u8] = buf.as_mut();
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return Err(Error::from_reason("buffer length must be even (BE int16)"));
     }
     let mut filter = Lowpass3_4k16k::new();

--- a/rust/src/g722.rs
+++ b/rust/src/g722.rs
@@ -192,7 +192,7 @@ mod tests {
             .collect();
         let encoded = enc.encode(&samples);
         assert_eq!(encoded.len(), 160, "64 kbit/s → 160 bytes per 20 ms");
-        let decoded = dec.decode(&encoded);
+        let decoded = dec.decode(encoded);
         assert_eq!(decoded.len(), 320, "decoder produces 16 kHz samples");
     }
 }

--- a/rust/src/portpool.rs
+++ b/rust/src/portpool.rs
@@ -28,7 +28,7 @@ static POOL: Mutex<Option<PortPool>> = Mutex::new(None);
 /// pool is replaced wholesale).
 pub fn init(start: u16, end: u16) {
     let mut p = start;
-    if p % 2 != 0 {
+    if !p.is_multiple_of(2) {
         p = p.saturating_add(1);
     }
     let mut q = VecDeque::new();

--- a/rust/src/stun.rs
+++ b/rust/src/stun.rs
@@ -130,12 +130,11 @@ fn walk_attributes(pk: &mut [u8], remote_key: &[u8]) -> bool {
                     return false;
                 }
             }
-            0x8028 => {
+            0x8028
                 // FINGERPRINT
-                if !verify_fingerprint(pk, off) {
+                if !verify_fingerprint(pk, off) => {
                     return false;
                 }
-            }
             // USERNAME / PRIORITY / USE-CANDIDATE / ICE-CONTROLLING /
             // GOOG-NETWORK-INFO — accept without validation.
             _ => {}

--- a/rust/src/tone.rs
+++ b/rust/src/tone.rs
@@ -120,7 +120,7 @@ fn gen_block(out: &mut [i16], freq_spec: &str) {
     };
 
     // Detect operator: `+` sum, `~` sweep. `x` modulation not implemented (matches C++).
-    let op_pos = freq_part.find(|c: char| c == '+' || c == '~' || c == 'x');
+    let op_pos = freq_part.find(['+', '~', 'x']);
     match op_pos {
         None => {
             let f: f64 = freq_part.parse().unwrap_or(0.0);
@@ -130,13 +130,13 @@ fn gen_block(out: &mut [i16], freq_spec: &str) {
             let op = freq_part.as_bytes()[p] as char;
             match op {
                 '+' => {
-                    for part in freq_part.split(|c: char| c == '+' || c == 'x' || c == '~') {
+                    for part in freq_part.split(['+', 'x', '~']) {
                         let f: f64 = part.parse().unwrap_or(0.0);
                         gentone(out, f, f, amp.start, amp.end, SAMPLE_RATE);
                     }
                 }
                 '~' => {
-                    let mut parts = freq_part.split(|c: char| c == '+' || c == 'x' || c == '~');
+                    let mut parts = freq_part.split(['+', 'x', '~']);
                     let f1: f64 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
                     let f2: f64 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(f1);
                     gentone(out, f1, f2, amp.start, amp.end, SAMPLE_RATE);
@@ -193,6 +193,7 @@ fn append_to_wav(filename: &Path, new_data: &[u8]) -> Result<()> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(filename)
         .map_err(|e| Error::from_reason(format!("open {filename:?}: {e}")))?;
 


### PR DESCRIPTION
Fixes the remaining CI failures on `main`. Both **Build** and **Rust CI** have been red; this PR addresses the failures that surfaced *after* the already-merged libilbc submodule-checkout fix. Combined into one PR because the failures were interlocked — each was masking the next, so only fixing both turns `main` green.

Both checks pass on this branch: **Build** (incl. emulated linux/arm64) and **Rust CI**.

## Commit 1 — Build (Dockerfile app stage)
Two latent bugs, never reached before because the build died earlier:
- `npm ci` failed with **exit 127** — the `app` stage installed `nodejs` but not `npm`.
- With npm present, `npm ci` then failed **EUSAGE** — the stage copied only `index.js package.json`, omitting the committed `package-lock.json`.

Fix: add `npm` to the app-stage `apk add`, and copy `package-lock.json`.
Verified: `docker build --target app` completes end-to-end (`npm ci: "added 1 package, audited 2 packages"`).

## Commit 2 — Rust CI (rustfmt + clippy)
CI's `dtolnay/rust-toolchain@stable` now resolves to **rustc 1.96.0**. On `main`, rustfmt fails first, masking clippy — so a fmt-only fix would still leave Rust CI red at clippy (the crate sets `#![deny(clippy::all)]`, 29 findings).

- **rustfmt**: `cargo fmt --all` (one single-line fn body in codec.rs under 1.96).
- **clippy**: auto-fixed the mechanical lints; hand-fixed `unnecessary_unwrap`, `manual_unwrap_or_default`, `manual_checked_ops`, `type_complexity`, `suspicious_open_options`, `field_reassign_with_default` (tests), and `enum_variant_names` (`Event::TelephoneEvent` → `Telephone`).
- `large_enum_variant` on the internal `Mode` enum is `#[allow]`'d with a rationale rather than boxed — `Local` is the hot/common variant, so boxing it would add a per-tick heap indirection.

### Behavioral safety
All changes are behavior-preserving. Every hunk was audited; notably:
- The **DTMF decoder logic** (`dtmf.rs` `DtmfReceiver`) is **byte-for-byte unchanged** (only a test-local type alias) — the real-world provider tuning is intact.
- `Event::TelephoneEvent`→`Telephone` is internal only; the JS event string `"telephone-event"` is a separate literal.
- `suspicious_open_options` adds `.truncate(false)`, which *is* the prior default — append semantics preserved.
- The stun.rs `if`→match-guard conversion was traced by hand: the `_ => {}` arm is a no-op, so control flow is identical.

### Validation
On the real CI toolchain (**rustc 1.96.0**, with `libilbc` + `libspandsp`):
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --lib --locked` (77 passed)
- `docker build --target app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
